### PR TITLE
Added support to add a uk none ltd company

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/uktrade/data-hub-fe-beta2"
   },
   "dependencies": {
-    "@uktrade/trade_elements": "^3.0.0",
+    "@uktrade/trade_elements": "^3.0.4",
     "axios": "^0.15.2",
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.1.1",

--- a/src/controllers/companyaddcontroller.js
+++ b/src/controllers/companyaddcontroller.js
@@ -2,7 +2,7 @@ const express = require('express')
 const Q = require('q')
 const winston = require('winston')
 const { ukOtherCompanyOptions, foreignOtherCompanyOptions } = require('../options')
-const { isBlank, toQueryString } = require('../lib/controllerutils')
+const { isBlank, toQueryString, genCSRF } = require('../lib/controllerutils')
 const searchService = require('../services/searchservice')
 const companyService = require('../services/companyservice')
 const companyFormattingService = require('../services/companyformattingservice')
@@ -11,6 +11,7 @@ const { companyDetailsLabels, chDetailsLabels, companyTypeOptions } = require('.
 const router = express.Router()
 
 function getAddStepOne (req, res, next) {
+  genCSRF(req, res)
   res.render('company/add-step-1.html', {
     ukOtherCompanyOptions,
     foreignOtherCompanyOptions,
@@ -72,6 +73,8 @@ function postAddStepOne (req, res, next) {
 }
 
 function getAddStepTwo (req, res, next) {
+  genCSRF(req, res)
+
   // If there is no search, just render.
   res.locals.companyTypeOptions = companyTypeOptions
 

--- a/src/controllers/interactioncontroller.js
+++ b/src/controllers/interactioncontroller.js
@@ -26,6 +26,7 @@ function getCommon (req, res, next) {
 }
 
 function getAddStep1 (req, res) {
+  controllerUtils.genCSRF(req, res)
   const interactionTypes = [...metadataRepository.interactionTypeOptions, { id: 999, name: 'Service delivery', selectable: true }]
 
   const selectableTypes = interactionTypes
@@ -80,6 +81,7 @@ function postAddStep1 (req, res) {
 }
 
 function getInteractionEdit (req, res, next) {
+  controllerUtils.genCSRF(req, res)
   Q.spawn(function *() {
     try {
       const token = req.session.token

--- a/src/controllers/servicedeliverycontroller.js
+++ b/src/controllers/servicedeliverycontroller.js
@@ -8,7 +8,7 @@ const serviceDeliveryRepository = require('../repositorys/servicedeliveryreposit
 const serviceDeliverylabels = require('../labels/servicedelivery')
 const serviceDeliveryService = require('../services/servicedeliveryservice')
 const formatDate = require('../lib/date').formatDate
-
+const genCSRF = controllerUtils.genCSRF
 const router = express.Router()
 
 function getCommon (req, res, next) {
@@ -26,6 +26,7 @@ function getCommon (req, res, next) {
 }
 
 function getServiceDeliveryEdit (req, res, next) {
+  genCSRF(req, res)
   Q.spawn(function *() {
     try {
       const token = req.session.token

--- a/src/lib/controllerutils.js
+++ b/src/lib/controllerutils.js
@@ -87,9 +87,7 @@ function nullEmptyFields (data) {
 function genCSRF (req, res) {
   const token = guid()
   req.session.csrfToken = token
-  if (res) {
-    res.set('x-csrf-token', token)
-  }
+  res.locals.csrfToken = token
   return token
 }
 

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -1,9 +1,7 @@
 const winston = require('winston')
-const { genCSRF } = require('../lib/controllerutils')
 
 module.exports = (req, res, next) => {
   if (req.method !== 'POST' || req.url === '/login') {
-    res.locals.csrfToken = genCSRF(req, res)
     return next()
   }
 
@@ -32,6 +30,5 @@ module.exports = (req, res, next) => {
 
   winston.debug('csrf:end')
   delete req.body._csrf_token
-  res.locals.csrfToken = genCSRF(req, res)
   return next()
 }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -17,7 +17,7 @@ const managedOptions = [
 
 const ukOtherCompanyOptions = [
   'Charity',
-  'Government department',
+  'Government dept',
   'Intermediary',
   'Limited partnership',
   'Partnership',
@@ -26,7 +26,7 @@ const ukOtherCompanyOptions = [
 const foreignOtherCompanyOptions = [
   'Charity',
   'Company',
-  'Government department',
+  'Government dept',
   'Intermediary',
   'Limited partnership',
   'Partnership',

--- a/src/views/company/edit-ltd.html
+++ b/src/views/company/edit-ltd.html
@@ -54,7 +54,7 @@
           <div class="form-group form-group--postcode">{# hide for none js #}
             <label class="form-label-bold">Postcode</label>
             <input class="form-control postcode-lookup-value postcode-lookup-field" autoComplete="off" value="">
-            <button class="button button-secondary postcode-lookup-button" type="button">Find UK Address</button>
+            <button class="button button-secondary postcode-lookup-button" type="button">Find UK address</button>
           </div>
           {# dropdown of suggestions #}
           <div class="form-group form-group--address-suggestions">
@@ -66,8 +66,8 @@
 
           {{ trade.textbox("trading_address_1", label="Business and street (optional)", value=company.trading_address_1, error=errors.trading_address_1) }}
           {{ trade.textbox("trading_address_2", value=company.trading_address_2, error=errors.trading_address_2) }}
-          {{ trade.textbox("trading_address_town", label="Town of city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
-          {{ trade.textbox("trading_address_county", label="County (optonal)", value=company.trading_address_county, error=errors.trading_address_county) }}
+          {{ trade.textbox("trading_address_town", label="Town or city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
+          {{ trade.textbox("trading_address_county", label="County (optional)", value=company.trading_address_county, error=errors.trading_address_county) }}
           {{ trade.textbox("trading_address_postcode", label="Postcode (optional)", value=company.trading_address_postcode, error=errors.trading_address_postcode) }}
           {{ trade.dropdown("trading_address_country", class="hidde", label="Country", emptyLabel="Pick a value", value=company.trading_address_country, options=countryOptions, errors=trading_address_country)}}
         </fieldset>

--- a/src/views/company/edit-nonuk.html
+++ b/src/views/company/edit-nonuk.html
@@ -46,7 +46,7 @@
           }}
           {{ trade.textbox("registered_address_1", label="Business and street (optional)", value=company.registered_address_1, error=errors.registered_address_1) }}
           {{ trade.textbox("registered_address_2", value=company.registered_address_2, error=errors.registered_address_2) }}
-          {{ trade.textbox("registered_address_town", label="Town of city (optional)", value=company.registered_address_town, error=errors.registered_address_town) }}
+          {{ trade.textbox("registered_address_town", label="Town or city (optional)", value=company.registered_address_town, error=errors.registered_address_town) }}
           {{ trade.textbox("registered_address_postcode", label="Postcode", value=company.registered_address_postcode, error=errors.registered_address_postcode) }}
         </fieldset>
 
@@ -78,7 +78,7 @@
           }}
           {{ trade.textbox("trading_address_1", label="Business and street (optional)", value=company.trading_address_1, error=errors.trading_address_1) }}
           {{ trade.textbox("trading_address_2", value=company.trading_address_2, error=errors.trading_address_2) }}
-          {{ trade.textbox("trading_address_town", label="Town of city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
+          {{ trade.textbox("trading_address_town", label="Town or city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
           {{ trade.textbox("trading_address_postcode", label="Postcode", value=company.trading_address_postcode, error=errors.trading_address_postcode) }}
         </fieldset>
 

--- a/src/views/company/edit-ukother.html
+++ b/src/views/company/edit-ukother.html
@@ -34,7 +34,7 @@
           <div class="form-group form-group--postcode">{# hide for none js #}
             <label class="form-label-bold">Postcode</label>
             <input class="form-control postcode-lookup-value postcode-lookup-field" autoComplete="off" value="">
-            <button class="button button-secondary postcode-lookup-button" type="button">Find UK Address</button>
+            <button class="button button-secondary postcode-lookup-button" type="button">Find UK address</button>
           </div>
           {# dropdown of suggestions #}
           <div class="form-group form-group--address-suggestions">

--- a/src/views/company/edit-ukother.html
+++ b/src/views/company/edit-ukother.html
@@ -11,39 +11,31 @@
           <div id="business-type" class="key-value__key form-label-bold">Business type
             <a href="/company/add-step-1" class="button-link">Change</a>
           </div>
-          <div class="key-value__value" aria-labelledby="business-type">UK {{businessType}}</div>
+          <div class="key-value__value" aria-labelledby="business-type">{{business_type.name}}</div>
         </div>
       </div>
 
-      <div class="section">
-        {% if chDetails %}
-          {{ trade.keyvaluetable(chDetails, labels=chDetailsLabels, keyorder=chDetailsDisplayOrder, class="table--small") }}
-        {% endif %}
-      </div>
-
       <form method="POST">
-        <input type="hidden" name="business_type" value="{{business_type}}">
+        <input type="hidden" name="_csrf_token" value="{{csrfToken}}">
+        <input type="hidden" name="business_type" value="{{business_type.id}}">
         <input type="hidden" name="uk_based" value="true">
 
         {{ trade.textbox("name", label="Name", value=company.name, error=errors.name) }}
-        {{ trade.textbox("alias", label="Trading name (optional)", value=company.alias, error=error.alias) }}
 
-        <fieldset id="registered-address-wrapper" class="fieldset--address {% if errors.registered_address %}error{% endif %} lookup-address-js">
-          <legend class="form-label-bold">
-            Primary address
-            {% if errors.registered_address %}<span class="error-message">{{errors.registered_address}}</span>{% endif %}
-          </legend>
+        {{ trade.textbox("alias", label="Trading name", value=company.alias, error=errors.alias) }}
+
+        <fieldset id="registered-address-wrapper" class="fieldset--address lookup-address-js">
+          <div class="form-group"><legend class="form-label-bold">Primary address</legend></div>
           <div class="key-value key-value--vertical form-group">
             <div id="registered-address-contry-label" class="key-value__key form-label-bold">Country</div>
             <div class="key-value__value" aria-labelledby="registered-address-contry-label">United Kingdom</div>
+            <!-- add hidden field for country -->
           </div>
 
           <div class="form-group form-group--postcode">{# hide for none js #}
             <label class="form-label-bold">Postcode</label>
             <input class="form-control postcode-lookup-value postcode-lookup-field" autoComplete="off" value="">
-            <button class="button button-secondary postcode-lookup-button" type="button">
-              Find UK Address
-            </button>
+            <button class="button button-secondary postcode-lookup-button" type="button">Find UK Address</button>
           </div>
           {# dropdown of suggestions #}
           <div class="form-group form-group--address-suggestions">
@@ -57,26 +49,18 @@
           {{ trade.textbox("registered_address_2", value=company.registered_address_2, error=errors.registered_address_2) }}
           {{ trade.textbox("registered_address_town", label="Town of city (optional)", value=company.registered_address_town, error=errors.registered_address_town) }}
           {{ trade.textbox("registered_address_county", label="County (optonal)", value=company.registered_address_county, error=errors.registered_address_county) }}
-          {{ trade.textbox("registered_address_postcode", label="Postcode (optional)", value=company.registered_address_postcode, error=errors.registered_address_postcode )}}
+          {{ trade.textbox("registered_address_postcode", label="Postcode (optional)", value=company.registered_address_postcode, error=errors.registered_address_postcode) }}
+          <input type="hidden" name="registered_address_country" value="{{unitedKingdom}}">
         </fieldset>
 
-        <fieldset class="inline form-group form-group__checkbox-group form-group__radiohide">
-          <legend class='form-label-bold'>Is the trading address the same as the primary address?</legend>
-          <label
-            class="block-label selection-button-radio"
-            for="trading_address_same_as_registered_yes">
-            <input id="trading_address_same_as_registered_yes" type="radio" name="trading_address_same_as_registered" value="yes" {% if company.trading_address_same_as_registered == true %}checked{% endif %}>
-            Yes
-          </label>
-          <label
-            class="block-label selection-button-radio {% if company.trading_address_same_as_registered == false %}selected{% endif %}"
-            for="trading_address_same_as_registered_no">
-            <input id="trading_address_same_as_registered_no" type="radio" name="trading_address_same_as_registered" value="no" {% if company.trading_address_same_as_registered == false %}checked{% endif %}>
-            No
-          </label>
-        </fieldset>
+        <div class="form-group">
+          <div class="form-label-bold">Trading address (optional)</div>
+          <button id="add-trading-address" class="button-link{%if showTradingAddress == true %}hidden{% endif %}" type="button">Add trading address</button>
+          <button id="remove-trading-address" class="button-link{%if showTradingAddress == false %} hidden{% endif %}" type="button">Remove trading address</button>
+        </div>
 
-        <fieldset id="trading-address-wrapper" class="fieldset--address panel panel-border-narrow lookup-address-js">
+        <fieldset id="trading-address-wrapper"
+          class="fieldset--address lookup-address-js{%if showTradingAddress == false %} hidden{% endif %}">
           <div class="key-value key-value--vertical form-group">
             <div id="trading-address-contry-label" class="key-value__key form-label-bold">Country</div>
             <div class="key-value__value" aria-labelledby="trading-address-contry-label">United Kingdom</div>
@@ -85,9 +69,7 @@
           <div class="form-group form-group--postcode">{# hide for none js #}
             <label class="form-label-bold">Postcode</label>
             <input class="form-control postcode-lookup-value postcode-lookup-field" autoComplete="off" value="">
-            <button class="button button-secondary postcode-lookup-button" type="button">
-              Find UK Address
-            </button>
+            <button class="button button-secondary postcode-lookup-button" type="button">Find UK Address</button>
           </div>
           {# dropdown of suggestions #}
           <div class="form-group form-group--address-suggestions">
@@ -102,54 +84,30 @@
           {{ trade.textbox("trading_address_town", label="Town of city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
           {{ trade.textbox("trading_address_county", label="County (optonal)", value=company.trading_address_county, error=errors.trading_address_county) }}
           {{ trade.textbox("trading_address_postcode", label="Postcode (optional)", value=company.trading_address_postcode, error=errors.trading_address_postcode) }}
+          <input type="hidden" name="trading_address_country" value="{{company.trading_address_country}}">
         </fieldset>
 
-        {{ trade.dropdown("uk_region", label="UK region", emptyLabel="Pick a value", value=company.uk_region, options=regionOptions) }}
-
-        <fieldset class="form-group form-group__checkbox-group form-group__radiohide">
-          <div class="inline">
-            <legend class='form-label-bold'>Is this a headquarters?</legend>
+        {{ trade.dropdown("uk_region", label="UK region", emptyLabel="Pick a value", value=company.uk_region, options=regionOptions, error=errors.uk_region) }}
+        <fieldset class="form-group form-group__checkbox-group">
+          <legend class="form-label-bold">Is this a headquarters?</legend>
+          <label
+            class="block-label selection-button-radio{% if not company.headquarter_type or company.headquarter_type == '' %} selected{% endif %}">
+            <input name="headquarters" type="radio" value="" {% if not company.headquarter_type or company.headquarter_type == '' %} selected{% endif %}>
+            Not a headquarters
+          </label>
+          {% for option in headquarterOptions %}
             <label
-              class="block-label selection-button-radio {% if showHeadquarters == true %}selected{% endif %}"
-              for="is_headquarters_yes">
-              <input id="is_headquarters_yes" name="is_headquarters" type="radio" value="yes" {% if showHeadquarters == true %}checked{% endif %}>
-              Yes
+              class="block-label selection-button-radio ">
+              <input name="headquarters" type="radio" value="{{option.name}}" {% if option.id == company.headquarters %}checked{% endif %}>
+              {{ hqLabels[option.name] }}
             </label>
-            <label
-              class="block-label selection-button-radio {% if showHeadquarters == false %}selected{% endif %}"
-              for="is_headquarters_no">
-              <input id="is_headquarters_no" name="is_headquarters" type="radio" value="no" {% if showHeadquarters == false %}checked{% endif %}>
-              No
-            </label>
-          </div>
-
-          <div id="headquarters-type-wrapper" class="panel panel-border-narrow">
-            <legend class='form-label-bold visually-hidden'>Headquarters type?</legend>
-            <label
-              class="block-label selection-button-radio {% if company.headquarters == "ukhq" %}selected{% endif %}"
-              for="ukhq">
-              <input id="ukhq" name="headquarters" type="radio" value="ukhq" {% if company.headquarters == "ukhq"  %}checked{% endif %}>
-              UK headquarters (UK HQ)
-            </label>
-            <label
-              class="block-label selection-button-radio {% if company.headquarters == "ehq" %}selected{% endif %}"
-              for="ehq">
-              <input id="ehq" name="headquarters" type="radio" value="ehq" {% if company.headquarters == "ehq" %}checked{% endif %}>
-              European headquarters (EHQ)
-            </label>
-            <label
-              class="block-label selection-button-radio {% if company.headquarters == "ghq" %}selected{% endif %}"
-              for="ghq">
-              <input id="ghq" name="headquarters" type="radio" value="ghq" {% if company.headquarters == "ghq" %}checked{% endif %}>
-              Global headquarters (GHQ)
-            </label>
-          </div>
+          {% endfor %}
         </fieldset>
-        {{ trade.dropdown("sector", label="Sector", emptyLabel="Pick a value", value=company.sector, options=sectorOptions) }}
-        {{ trade.textbox("website", label="Website (optional)", value=company.website) }}
-        {{ trade.textarea("description", label="Business description (optional)", value=company.description) }}
-        {{ trade.dropdown("employee_range", label="Employees (optional)", emptyLabel="Pick a value", value=company.employee_ranage, options=employeeOptions) }}
-        {{ trade.dropdown("turnover_range", label="Annual turnover (optional)", emptyLabel="Pick a value", value=company.turnover_ranage, options=turnoverOptions) }}
+        {{ trade.dropdown("sector", label="Sector", emptyLabel="Pick a value", value=company.sector, options=sectorOptions, error=errors.sector) }}
+        {{ trade.textbox("website", label="Website (optional)", value=company.website, error=errors.website) }}
+        {{ trade.textarea("description", label="Business description (optional)", value=company.description, error=errors.description) }}
+        {{ trade.dropdown("employee_range", label="Number of employees (optional)", emptyLabel="Pick a value", value=company.employee_range, options=employeeOptions, error=errors.employee_range) }}
+        {{ trade.dropdown("turnover_range", label="Annual turnover (optional)", emptyLabel="Pick a value", value=company.turnover_ranage, options=turnoverOptions, error=errors.turnover_range) }}
 
         {% if company.id %}
           {{ trade.save(backUrl=referer) }}
@@ -157,7 +115,6 @@
           {{ trade.save(buttonText="Save and create", backUrl=referer) }}
         {% endif %}
       </form>
-
     </div>
   </div>
   <script src="/javascripts/companyedit.bundle.js"></script>

--- a/src/views/company/edit-ukother.html
+++ b/src/views/company/edit-ukother.html
@@ -29,7 +29,6 @@
           <div class="key-value key-value--vertical form-group">
             <div id="registered-address-contry-label" class="key-value__key form-label-bold">Country</div>
             <div class="key-value__value" aria-labelledby="registered-address-contry-label">United Kingdom</div>
-            <!-- add hidden field for country -->
           </div>
 
           <div class="form-group form-group--postcode">{# hide for none js #}
@@ -47,8 +46,8 @@
 
           {{ trade.textbox("registered_address_1", label="Business and street (optional)", value=company.registered_address_1, error=errors.registered_address_1) }}
           {{ trade.textbox("registered_address_2", value=company.registered_address_2, error=errors.registered_address_2) }}
-          {{ trade.textbox("registered_address_town", label="Town of city (optional)", value=company.registered_address_town, error=errors.registered_address_town) }}
-          {{ trade.textbox("registered_address_county", label="County (optonal)", value=company.registered_address_county, error=errors.registered_address_county) }}
+          {{ trade.textbox("registered_address_town", label="Town or city (optional)", value=company.registered_address_town, error=errors.registered_address_town) }}
+          {{ trade.textbox("registered_address_county", label="County (optional)", value=company.registered_address_county, error=errors.registered_address_county) }}
           {{ trade.textbox("registered_address_postcode", label="Postcode (optional)", value=company.registered_address_postcode, error=errors.registered_address_postcode) }}
           <input type="hidden" name="registered_address_country" value="{{unitedKingdom}}">
         </fieldset>
@@ -69,7 +68,7 @@
           <div class="form-group form-group--postcode">{# hide for none js #}
             <label class="form-label-bold">Postcode</label>
             <input class="form-control postcode-lookup-value postcode-lookup-field" autoComplete="off" value="">
-            <button class="button button-secondary postcode-lookup-button" type="button">Find UK Address</button>
+            <button class="button button-secondary postcode-lookup-button" type="button">Find UK address</button>
           </div>
           {# dropdown of suggestions #}
           <div class="form-group form-group--address-suggestions">
@@ -81,8 +80,8 @@
 
           {{ trade.textbox("trading_address_1", label="Business and street (optional)", value=company.trading_address_1, error=errors.trading_address_1) }}
           {{ trade.textbox("trading_address_2", value=company.trading_address_2, error=errors.trading_address_2) }}
-          {{ trade.textbox("trading_address_town", label="Town of city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
-          {{ trade.textbox("trading_address_county", label="County (optonal)", value=company.trading_address_county, error=errors.trading_address_county) }}
+          {{ trade.textbox("trading_address_town", label="Town or city (optional)", value=company.trading_address_town, error=errors.trading_address_town) }}
+          {{ trade.textbox("trading_address_county", label="County (optional)", value=company.trading_address_county, error=errors.trading_address_county) }}
           {{ trade.textbox("trading_address_postcode", label="Postcode (optional)", value=company.trading_address_postcode, error=errors.trading_address_postcode) }}
           <input type="hidden" name="trading_address_country" value="{{company.trading_address_country}}">
         </fieldset>

--- a/test/controllers/companyaddcontroller.test.js
+++ b/test/controllers/companyaddcontroller.test.js
@@ -52,14 +52,14 @@ describe('Company add controller', function () {
 
   describe('Get step 1', function () {
     it('should return options for company types', function (done) {
-      const req = {}
+      const req = {session: {}}
       const res = {
         locals: {},
         render: function (template, options) {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.ukOtherCompanyOptions).to.deep.equal([
             'Charity',
-            'Government department',
+            'Government dept',
             'Intermediary',
             'Limited partnership',
             'Partnership',
@@ -68,7 +68,7 @@ describe('Company add controller', function () {
           expect(allOptions.foreignOtherCompanyOptions).to.deep.equal([
             'Charity',
             'Company',
-            'Government department',
+            'Government dept',
             'Intermediary',
             'Limited partnership',
             'Partnership',
@@ -81,7 +81,7 @@ describe('Company add controller', function () {
       companyAddController.getAddStepOne(req, res)
     })
     it('should return labels for the types and error messages', function (done) {
-      const req = {}
+      const req = {session: {}}
       const res = {
         locals: {},
         render: function (template, options) {
@@ -101,7 +101,7 @@ describe('Company add controller', function () {
     })
     it('should pass through the request body to show previosuly selected options', function (done) {
       const body = { business_type: '1231231231232' }
-      const req = { body }
+      const req = { body, session: {}}
       const res = {
         locals: {},
         render: function (template, options) {
@@ -126,7 +126,8 @@ describe('Company add controller', function () {
         const req = {
           body: {
             business_type: 'ltd'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -142,7 +143,8 @@ describe('Company add controller', function () {
           body: {
             business_type: 'ukother',
             business_type_uk_other: 'Charity'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -158,7 +160,8 @@ describe('Company add controller', function () {
           body: {
             business_type: 'forother',
             business_type_for_other: 'Charity'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -173,7 +176,8 @@ describe('Company add controller', function () {
     describe('errors', function () {
       it('should show an error when no option selected', function (done) {
         const req = {
-          body: {}
+          body: {},
+          session: {}
         }
         const res = {
           locals: {},
@@ -189,7 +193,8 @@ describe('Company add controller', function () {
         const req = {
           body: {
             business_type: 'ukother'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -205,7 +210,8 @@ describe('Company add controller', function () {
         const req = {
           body: {
             business_type: 'forother'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -226,7 +232,8 @@ describe('Company add controller', function () {
           query: {
             business_type: 'ltd',
             country: 'uk'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -242,7 +249,8 @@ describe('Company add controller', function () {
           query: {
             business_type: 'ltd',
             country: 'uk'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},
@@ -264,7 +272,8 @@ describe('Company add controller', function () {
           query: {
             business_type: 'ltd',
             country: 'uk'
-          }
+          },
+          session: {}
         }
         const res = {
           locals: {},

--- a/test/controllers/companycontroller.getdetails.test.js
+++ b/test/controllers/companycontroller.getdetails.test.js
@@ -125,7 +125,7 @@ describe('Company controller, getDetails', function () {
         name: 'Test company'
       }
     }
-    const req = {}
+    const req = {session: {}}
     const res = {
       locals: { company },
       render: function (url, options) {
@@ -286,7 +286,6 @@ describe('Company controller, getDetails', function () {
       }
     }
     const next = function (error) {
-      console.log(error)
       expect(false).to.equal(true)
     }
     companyController.getDetails(req, res, next)

--- a/test/controllers/companycontroller.getedit.test.js
+++ b/test/controllers/companycontroller.getedit.test.js
@@ -47,8 +47,6 @@ describe('Company controller, getEdit', function () {
     companyController = proxyquire('../../src/controllers/companycontroller', {
       '../services/searchservice': {
         getCompanyForSource: function (token, id, source) {
-          getSource = source
-          getId = id
           return new Promise((resolve) => {
             resolve(fakeCompany)
           })
@@ -123,6 +121,10 @@ describe('Company controller, getEdit', function () {
             'name': 'Undefined',
             'selectable': true
           }
+        ],
+        countryOptions: [
+          { id: '9999', name: 'United Kingdom' },
+          { id: '12344', name: 'France' }
         ]
       },
       '../repositorys/companyrepository': fakeCompanyRepository
@@ -131,7 +133,7 @@ describe('Company controller, getEdit', function () {
 
   describe('pick edit form', function () {
     it('should render the uk ltd form for records with companies house data', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: {
           company: {
@@ -155,7 +157,8 @@ describe('Company controller, getEdit', function () {
         query: {
           business_type: 'Charity',
           country: 'uk'
-        }
+        },
+        session: {}
       }
       const res = {
         locals: {
@@ -169,7 +172,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should render the uk other form for an existing UK company without companies house data', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: {
           company: {
@@ -194,7 +197,8 @@ describe('Company controller, getEdit', function () {
         query: {
           business_type: 'Charity',
           country: 'non-uk'
-        }
+        },
+        session: {}
       }
       const res = {
         locals: {
@@ -208,7 +212,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should render the non uk form for existing none uk company', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: {
           company: {
@@ -241,7 +245,7 @@ describe('Company controller, getEdit', function () {
     }
 
     it('should include option data', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -258,7 +262,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should include labels', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -271,7 +275,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should include formatted CH data if CH data is present', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -285,7 +289,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should include the business type and uk based indicator', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -303,7 +307,7 @@ describe('Company controller, getEdit', function () {
       companyController.editDetails(req, res)
     })
     it('should indicate to hide the trading address', function (done) {
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -316,7 +320,7 @@ describe('Company controller, getEdit', function () {
     })
     it('should indicate theres a trading address', function (done) {
       company.trading_address_country = { id: '1234', name: 'Spain' }
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
@@ -329,12 +333,31 @@ describe('Company controller, getEdit', function () {
     })
     it('should indicate there is not a trading address', function (done) {
       company.trading_address_country = null
-      const req = {}
+      const req = { session: {} }
       const res = {
         locals: { company },
         render: function (url, options) {
           const allOptions = mergeLocals(res, options)
           expect(allOptions.showTradingAddress).to.not.be.true
+          done()
+        }
+      }
+      companyController.editDetails(req, res)
+    })
+    it('should include the id for the united kingdom when editing a uk none ltd', function (done) {
+      const req = {
+        query: {
+          business_type: 'Charity',
+          country: 'uk'
+        },
+        session: {}
+      }
+      const res = {
+        locals: {},
+        render: function (url, options) {
+          const allOptions = mergeLocals(res, options)
+          expect(allOptions.unitedKingdom).to.eq('9999')
+          expect(allOptions.uk_based).to.equal(true)
           done()
         }
       }
@@ -399,34 +422,34 @@ describe('Company controller, getEdit', function () {
     })
 
     it('should include companies house data as hidden defaults in a uk ltd edit form', function () {
-      expect(document.querySelector('[name=company_number]').value).to.equal('1234')
-      expect(document.querySelector('[name=business_type]').value).to.equal('1111')
-      expect(document.querySelector('[name=uk_based]').value).to.equal('true')
-      expect(document.querySelector('[name=name]').value).to.equal('Freds test company')
-      expect(document.querySelector('[name=registered_address_1]').value).to.equal('address1')
-      expect(document.querySelector('[name=registered_address_2]').value).to.equal('address2')
-      expect(document.querySelector('[name=registered_address_3]').value).to.equal('address3')
-      expect(document.querySelector('[name=registered_address_4]').value).to.equal('address4')
-      expect(document.querySelector('[name=registered_address_town]').value).to.equal('addresstown')
-      expect(document.querySelector('[name=registered_address_county]').value).to.equal('addresscounty')
-      expect(document.querySelector('[name=registered_address_postcode]').value).to.equal('addresspostcode')
-      expect(document.querySelector('[name=registered_address_country]').value).to.equal('4444')
+      expect(document.querySelector('[type=hidden][name=company_number]').value).to.equal('1234')
+      expect(document.querySelector('[type=hidden][name=business_type]').value).to.equal('1111')
+      expect(document.querySelector('[type=hidden][name=uk_based]').value).to.equal('true')
+      expect(document.querySelector('[type=hidden][name=name]').value).to.equal('Freds test company')
+      expect(document.querySelector('[type=hidden][name=registered_address_1]').value).to.equal('address1')
+      expect(document.querySelector('[type=hidden][name=registered_address_2]').value).to.equal('address2')
+      expect(document.querySelector('[type=hidden][name=registered_address_3]').value).to.equal('address3')
+      expect(document.querySelector('[type=hidden][name=registered_address_4]').value).to.equal('address4')
+      expect(document.querySelector('[type=hidden][name=registered_address_town]').value).to.equal('addresstown')
+      expect(document.querySelector('[type=hidden][name=registered_address_county]').value).to.equal('addresscounty')
+      expect(document.querySelector('[type=hidden][name=registered_address_postcode]').value).to.equal('addresspostcode')
+      expect(document.querySelector('[type=hidden][name=registered_address_country]').value).to.equal('4444')
     })
     it('should include all the fields from the design (hidden and visible) for a ltd company', function () {
-      expect(document.querySelector('[name=alias]')).to.not.be.null
-      expect(document.querySelector('[name=trading_address_1]')).to.not.be.null
-      expect(document.querySelector('[name=trading_address_2]')).to.not.be.null
-      expect(document.querySelector('[name=trading_address_town]')).to.not.be.null
-      expect(document.querySelector('[name=trading_address_county]')).to.not.be.null
-      expect(document.querySelector('[name=trading_address_postcode]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=alias]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_1]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_2]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_town]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_county]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_postcode]')).to.not.be.null
       expect(document.querySelector('[name=trading_address_country]')).to.not.be.null
-      expect(document.querySelector('[name=uk_region]')).to.not.be.null
-      expect(document.querySelector('[name=headquarters]')).to.not.be.null
-      expect(document.querySelector('[name=sector]')).to.not.be.null
-      expect(document.querySelector('[name=website]')).to.not.be.null
-      expect(document.querySelector('[name=description]')).to.not.be.null
-      expect(document.querySelector('[name=employee_range]')).to.not.be.null
-      expect(document.querySelector('[name=turnover_range]')).to.not.be.null
+      expect(document.querySelector('select[name=uk_region]')).to.not.be.null
+      expect(document.querySelector('[type=radio][name=headquarters]')).to.not.be.null
+      expect(document.querySelector('select[name=sector]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=website]')).to.not.be.null
+      expect(document.querySelector('textarea[name=description]')).to.not.be.null
+      expect(document.querySelector('select[name=employee_range]')).to.not.be.null
+      expect(document.querySelector('select[name=turnover_range]')).to.not.be.null
     })
     it('should display the companies house data above the form', function () {
       const chDetailElement = document.querySelector('#ch-details')
@@ -436,6 +459,123 @@ describe('Company controller, getEdit', function () {
       expect(chDetails).to.include('1234')
       expect(chDetails).to.include('10 the street')
       expect(chDetails).to.include('Ltd')
+    })
+    it('should hide the trading address section by default and include a button to show it', function () {
+      expect(document.querySelector('#trading-address-wrapper').className).to.include('hidden')
+      expect(document.querySelector('#add-trading-address').className).to.not.include('hidden')
+      expect(document.querySelector('#remove-trading-address').className).to.include('hidden')
+    })
+    it('should show the trading address section and include the remove button if there is one', function (done) {
+      markup = nunjucks.render('../../src/views/company/edit-ltd.html', {
+        business_type: { id: '1111', name: 'Private limited company' },
+        company: {
+          countryOptions: [{id: 1, name: 'country'}],
+          company_number: '1234',
+          companies_house_data: {
+            name: 'Freds test company',
+            registered_address_1: 'address1',
+            registered_address_2: 'address2',
+            registered_address_3: 'address3',
+            registered_address_4: 'address4',
+            registered_address_town: 'addresstown',
+            registered_address_county: 'addresscounty',
+            registered_address_postcode: 'addresspostcode',
+            registered_address_country: 'addresscountry'
+          }
+        },
+        chDetails: {
+          name: 'fred',
+          company_number: '1234',
+          registered_address: '10 the street',
+          business_type: 'Ltd',
+          company_status: 'Active',
+          sic_code: '1234 - Thing'
+        },
+        chDetailsDisplayOrder: ['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'sic_code'],
+        chDetailsLabels: {
+          name: 'Registered company name',
+          company_number: 'Companies House number',
+          registered_address: 'Registered office address',
+          business_type: 'Company type',
+          company_status: 'Company status',
+          sic_code: 'Nature of business (SIC)',
+          incorporation_date: 'Incorporation date'
+        },
+        csrfToken: '2222',
+        showTradingAddress: true
+      })
+
+      jsdom.env(markup, (err, jsdomWindow) => {
+        if (err) {
+          throw new Error(err)  // eslint-disable-line no-new
+        }
+
+        document = jsdomWindow.document
+        expect(document.querySelector('#trading-address-wrapper').className).to.not.include('hidden')
+        expect(document.querySelector('#add-trading-address').className).to.include('hidden')
+        expect(document.querySelector('#remove-trading-address').className).to.not.include('hidden')
+        done()
+      })
+
+      expect(document.querySelector('#trading-address-wrapper').className).to.include('hidden')
+      expect(document.querySelector('#add-trading-address').className).to.not.include('hidden')
+      expect(document.querySelector('#remove-trading-address').className).to.include('hidden')
+    })
+  })
+  describe('edit none ltd company markup', function () {
+    let document
+    let markup
+
+    beforeEach(function (done) {
+      markup = nunjucks.render('../../src/views/company/edit-ukother.html', {
+        business_type: { id: '1111', name: 'Government dept' },
+        company: {
+          countryOptions: [{id: 1, name: 'country'}],
+          company_number: null,
+          companies_house_data: null
+        },
+        csrfToken: '2222',
+        showTradingAddress: false
+      })
+
+      jsdom.env(markup, (err, jsdomWindow) => {
+        if (err) {
+          throw new Error(err)  // eslint-disable-line no-new
+        }
+
+        document = jsdomWindow.document
+        done()
+      })
+    })
+
+    it('should include all the fields from the design (hidden and visible) for a ltd company', function () {
+      expect(document.querySelector('[type=text][name=company_number]')).to.be.null
+      expect(document.querySelector('[type=hidden][name=business_type]')).to.not.be.null
+      expect(document.querySelector('[type=hidden][name=uk_based]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=name]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=registered_address_1]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=registered_address_2]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=registered_address_town]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=registered_address_county]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=registered_address_postcode]')).to.not.be.null
+      expect(document.querySelector('[type=hidden][name=registered_address_country]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=alias]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_1]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_2]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_town]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_county]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=trading_address_postcode]')).to.not.be.null
+      expect(document.querySelector('[type=hidden][name=trading_address_country]')).to.not.be.null
+      expect(document.querySelector('select[name=uk_region]')).to.not.be.null
+      expect(document.querySelector('[type=radio][name=headquarters]')).to.not.be.null
+      expect(document.querySelector('select[name=sector]')).to.not.be.null
+      expect(document.querySelector('[type=text][name=website]')).to.not.be.null
+      expect(document.querySelector('textarea[name=description]')).to.not.be.null
+      expect(document.querySelector('select[name=employee_range]')).to.not.be.null
+      expect(document.querySelector('select[name=turnover_range]')).to.not.be.null
+    })
+    it('should not display the companies house data above the form', function () {
+      expect(document.querySelector('#ch-details')).to.be.null
     })
     it('should hide the trading address section by default and include a button to show it', function () {
       expect(document.querySelector('#trading-address-wrapper').className).to.include('hidden')


### PR DESCRIPTION
Slightly modified the controller logic to handle none ltd companies and the edge case you select a company type not in the cdm db.
Had to change CSRF generation. If a form was loaded and then a json looking to get an address, this invalidated the form token. Moved generation of tokens so that only happens when building a form.
Created a new layout for the none ltd uk companies to look like the design.