### PR TITLE
Rename 'Role' to 'Job title' in contacts table and fix adviser label in interaction form

### DIFF
--- a/src/controllers/companycontroller.js
+++ b/src/controllers/companycontroller.js
@@ -202,7 +202,7 @@ function getContacts (req, res) {
 
   const tableLabels = {
     name: 'Name',
-    job_title: 'Role',
+    job_title: 'Job title',
     telephone_number: 'Phone',
     email: 'Email'
   }

--- a/src/views/interaction/interaction-edit.html
+++ b/src/views/interaction/interaction-edit.html
@@ -54,7 +54,7 @@
     {{ trade.date('date', label=labels.date, value=interaction.date ) }}
 
     {{ trade.autocomplete('dit_advisor',
-      label=labels.advisor,
+      label=labels.dit_advisor,
       value=interaction.dit_advisor.id,
       displayvalue=interaction.dit_advisor.name,
       hint="Please start typing to search for an advisor",


### PR DESCRIPTION
Ports a couple of small changes from https://github.com/uktrade/data-hub-prototype.