### PR TITLE
Change address formatter to return null for empty address

### DIFF
--- a/src/lib/address.js
+++ b/src/lib/address.js
@@ -20,6 +20,10 @@ function getFormattedAddress (object, key) {
     addressStr += 'United Kingdom'
   }
 
+  if (addressStr.length === 0) {
+    return null
+  }
+
   return addressStr
 }
 

--- a/src/services/companyformattingservice.js
+++ b/src/services/companyformattingservice.js
@@ -1,8 +1,9 @@
 const { companyDetailsLabels, chDetailsLabels, hqLabels } = require('../labels/companylabels')
-const getFormattedAddress = require('../lib/address').getFormattedAddress
-const {titleCase} = require('../lib/textformatting')
-const {formatLongDate} = require('../lib/date')
+const { getFormattedAddress } = require('../lib/address')
+const { titleCase } = require('../lib/textformatting')
+const { formatLongDate } = require('../lib/date')
 const { getPrimarySectorName } = require('../lib/transformsectors')
+
 
 const companyDetailsDisplayOrder = Object.keys(companyDetailsLabels)
 const chDetailsDisplayOrder = Object.keys(chDetailsLabels)
@@ -48,12 +49,12 @@ function getDisplayCompany (company) {
   if (company.alias && company.alias.length > 0) displayCompany.alias = company.alias
 
   const registeredAddress = getFormattedAddress(company, 'registered')
-  if (registeredAddress && registeredAddress.length > 0) displayCompany.registered_address = registeredAddress
+  displayCompany.registered_address = registeredAddress
   if (company.registered_address_country && company.registered_address_country.name) {
     displayCompany.country = company.registered_address_country.name
   }
-  const tradingAddress = getFormattedAddress(company, 'trading')
-  if (tradingAddress && tradingAddress.length > 0) displayCompany.trading_address = tradingAddress
+
+  displayCompany.trading_address = getFormattedAddress(company, 'trading')
 
   if (!company.companies_house_data) {
     displayCompany.business_type = (company.business_type && company.business_type.name && company.business_type.name !== 'Undefined') ? company.business_type.name : null
@@ -68,7 +69,7 @@ function getDisplayCompany (company) {
 function getHeadingAddress (company) {
   // If this is a CDMS company
   const cdmsTradingAddress = getFormattedAddress(company, 'trading')
-  if (cdmsTradingAddress && cdmsTradingAddress.length > 0) {
+  if (cdmsTradingAddress) {
     return cdmsTradingAddress
   }
 
@@ -95,18 +96,8 @@ function parseRelatedData (companies) {
 
   return companies.map((company) => {
     const key = (company.trading_address_1 && company.trading_address_1.length > 0) ? 'trading' : 'registered'
+    let address = getFormattedAddress(company, key)
 
-    let address = ''
-    if (company[`${key}_address_town`] && company[`${key}_address_town`].length > 0) {
-      address += titleCase(`${company[`${key}_address_town`]}, `)
-    } else if (company[`${key}_address_county`] && company[`${key}_address_county`].length > 0) {
-      address += titleCase(`${company[`${key}_address_county`]}, `)
-    }
-    if (company[`${key}_address_country`] && company[`${key}_address_country`].name && company[`${key}_address_country`].name.length > 0) {
-      address += titleCase(company[`${key}_address_country`].name)
-    } else if (address.length > 0) {
-      address += 'United Kingdom'
-    }
     return {
       name: `<a href="/company/company_company/${company.id}">${company.alias || company.name}</a>`,
       address

--- a/src/services/companyformattingservice.js
+++ b/src/services/companyformattingservice.js
@@ -48,12 +48,12 @@ function getDisplayCompany (company) {
   if (company.alias && company.alias.length > 0) displayCompany.alias = company.alias
 
   const registeredAddress = getFormattedAddress(company, 'registered')
-  if (registeredAddress.length > 0) displayCompany.registered_address = registeredAddress
+  if (registeredAddress && registeredAddress.length > 0) displayCompany.registered_address = registeredAddress
   if (company.registered_address_country && company.registered_address_country.name) {
     displayCompany.country = company.registered_address_country.name
   }
   const tradingAddress = getFormattedAddress(company, 'trading')
-  if (tradingAddress.length > 0) displayCompany.trading_address = tradingAddress
+  if (tradingAddress && tradingAddress.length > 0) displayCompany.trading_address = tradingAddress
 
   if (!company.companies_house_data) {
     displayCompany.business_type = (company.business_type && company.business_type.name && company.business_type.name !== 'Undefined') ? company.business_type.name : null
@@ -68,7 +68,7 @@ function getDisplayCompany (company) {
 function getHeadingAddress (company) {
   // If this is a CDMS company
   const cdmsTradingAddress = getFormattedAddress(company, 'trading')
-  if (cdmsTradingAddress.length > 0) {
+  if (cdmsTradingAddress && cdmsTradingAddress.length > 0) {
     return cdmsTradingAddress
   }
 

--- a/test/lib/address.test.js
+++ b/test/lib/address.test.js
@@ -2,7 +2,25 @@
 const address = require('../../src/lib/address')
 
 describe('Address formatter', function () {
-  it('should format an address when', function () {
+  it('should format an address when it is fully populated.', function () {
+    const source = {
+      id: '12651151-2149-465e-871b-ac45bc568a62',
+      address_1: '10 The Street',
+      address_2: 'Warble',
+      address_3: '',
+      address_4: '',
+      address_town: 'Big Town',
+      address_county: 'Large County',
+      address_country: {
+        id: '1234',
+        name: 'Country'
+      },
+      address_postcode: 'LL1 1LL'
+    }
+    const actual = address.getFormattedAddress(source)
+    expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, Country')
+  })
+  it('should add United Kingdom to the address if no country is provided.', function () {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '10 The Street',
@@ -31,7 +49,7 @@ describe('Address formatter', function () {
     const actual = address.getFormattedAddress(source, 'trading')
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom')
   })
-  it('should return null when the address is emptyu', function () {
+  it('should return null when the address is empty', function () {
     const source = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
       address_1: '',

--- a/test/lib/address.test.js
+++ b/test/lib/address.test.js
@@ -1,0 +1,48 @@
+/* globals expect: true, describe: true, it: true, beforeEach: true */
+const address = require('../../src/lib/address')
+
+describe('Address formatter', function () {
+  it('should format an address when', function () {
+    const source = {
+      id: '12651151-2149-465e-871b-ac45bc568a62',
+      address_1: '10 The Street',
+      address_2: 'Warble',
+      address_3: '',
+      address_4: '',
+      address_town: 'Big Town',
+      address_county: 'Large County',
+      address_postcode: 'LL1 1LL'
+    }
+    const actual = address.getFormattedAddress(source)
+    expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom')
+  })
+  it('should format an address with field names containing a prefix', function () {
+    const source = {
+      id: '12651151-2149-465e-871b-ac45bc568a62',
+      trading_address_1: '10 The Street',
+      trading_address_2: 'Warble',
+      trading_address_3: '',
+      trading_address_4: '',
+      trading_address_town: 'Big Town',
+      trading_address_county: 'Large County',
+      trading_address_postcode: 'LL1 1LL'
+    }
+
+    const actual = address.getFormattedAddress(source, 'trading')
+    expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom')
+  })
+  it('should return null when the address is emptyu', function () {
+    const source = {
+      id: '12651151-2149-465e-871b-ac45bc568a62',
+      address_1: '',
+      address_2: '',
+      address_3: '',
+      address_4: '',
+      address_town: '',
+      address_county: '',
+      address_postcode: ''
+    }
+    const actual = address.getFormattedAddress(source)
+    expect(actual).to.be.null
+  })
+})


### PR DESCRIPTION
Previously an empty address returned an empty string, which would be shown on the screen. This was inconsistent with the decision to not show empty fields.