### PR TITLE
Replace all links to company details with a call to a function to  generate

### DIFF
--- a/src/controllers/contactcontroller.js
+++ b/src/controllers/contactcontroller.js
@@ -4,6 +4,7 @@ const Q = require('q')
 
 const contactRepository = require('../repositorys/contactrepository')
 const contactFormattingService = require('../services/contactformattingservice')
+const companyService = require('../services/companyservice')
 const { contactDetailsLabels } = require('../labels/contactlabels')
 const router = express.Router()
 
@@ -13,6 +14,7 @@ function getCommon (req, res, next) {
       try {
         res.locals.id = req.params.contactId
         res.locals.contact = yield contactRepository.getContact(req.session.token, res.locals.id)
+        res.locals.companyUrl = companyService.getViewCompanyLink(res.locals.contact.company)
         next()
       } catch (error) {
         winston.error(error)

--- a/src/controllers/searchcontroller.js
+++ b/src/controllers/searchcontroller.js
@@ -1,6 +1,9 @@
 const express = require('express')
+const companyRepository = require('../repositorys/companyrepository')
+const companyService = require('../services/companyservice')
 const searchService = require('../services/searchservice')
 const getPagination = require('../lib/pagination').getPagination
+const Q = require('q')
 
 const router = express.Router()
 
@@ -27,8 +30,24 @@ function get (req, res) {
     .catch(error => res.render('error', { error }))
 }
 
-router.get('/', get)
+function viewCompanyResult (req, res, next) {
+  if (req.params.source === 'company_companieshousecompany') {
+    res.redirect(`/company/view/ch/${req.params.id}`)
+  } else {
+    Q.spawn(function * () {
+      try {
+        const company = yield companyRepository.getDitCompany(req.session.token, req.params.id)
+        res.redirect(companyService.getCompanyUrl(company))
+      } catch (error) {
+        next(error)
+      }
+    })
+  }
+}
+
+router.get('/search', get)
+router.get('/viewcompanyresult/:source/:id', viewCompanyResult)
 
 module.exports = {
-  search: get, router
+  search: get, router, viewCompanyResult
 }

--- a/src/controllers/searchcontroller.js
+++ b/src/controllers/searchcontroller.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const companyRepository = require('../repositorys/companyrepository')
-const companyService = require('../services/companyservice')
+const { getViewCompanyLink } = require('../services/companyservice')
 const searchService = require('../services/searchservice')
 const getPagination = require('../lib/pagination').getPagination
 const Q = require('q')
@@ -37,7 +37,7 @@ function viewCompanyResult (req, res, next) {
     Q.spawn(function * () {
       try {
         const company = yield companyRepository.getDitCompany(req.session.token, req.params.id)
-        res.redirect(companyService.getCompanyUrl(company))
+        res.redirect(getViewCompanyLink(company))
       } catch (error) {
         next(error)
       }

--- a/src/controllers/servicedeliverycontroller.js
+++ b/src/controllers/servicedeliverycontroller.js
@@ -8,7 +8,8 @@ const { nullEmptyFields } = require('../lib/propertyhelpers')
 const metadataRepository = require('../repositorys/metadatarepository')
 const serviceDeliveryRepository = require('../repositorys/servicedeliveryrepository')
 const serviceDeliveryService = require('../services/servicedeliveryservice')
-const {getDisplayServiceDelivery} = require('../services/servicedeliveryformattingservice')
+const { getDisplayServiceDelivery } = require('../services/servicedeliveryformattingservice')
+const { getViewCompanyLink } = require('../services/companyservice')
 
 const serviceDeliveryDisplayOrder = ['company', 'dit_team', 'service', 'status', 'subject', 'notes', 'date', 'dit_advisor', 'uk_region', 'sector', 'contact', 'country_of_interest']
 const router = express.Router()
@@ -58,6 +59,7 @@ function getServiceDeliveryEdit (req, res, next) {
       res.locals.regionOptions = metadataRepository.regionOptions
       res.locals.statusOptions = metadataRepository.serviceDeliveryStatusOptions
       res.locals.eventOptions = metadataRepository.eventOptions
+      res.locals.companyUrl = getViewCompanyLink(res.locals.serviceDelivery.company)
 
       res.render('interaction/servicedelivery-edit')
     } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -145,7 +145,7 @@ app.use(interactionController.router)
 app.use(interactionEditController.router)
 app.use(serviceDeliveryController.router)
 
-app.use('/search', searchController.router)
+app.use(searchController.router)
 app.use(apiController.router)
 app.get('/', indexController)
 app.use('/ping.xml', pingdomController.get)

--- a/src/services/companyformattingservice.js
+++ b/src/services/companyformattingservice.js
@@ -3,6 +3,7 @@ const { getFormattedAddress } = require('../lib/address')
 const { titleCase } = require('../lib/textformatting')
 const { formatLongDate } = require('../lib/date')
 const { getPrimarySectorName } = require('../lib/transformsectors')
+const { getViewCompanyLink } = require('./companyservice')
 
 const companyDetailsDisplayOrder = Object.keys(companyDetailsLabels)
 const chDetailsDisplayOrder = Object.keys(chDetailsLabels)
@@ -96,9 +97,9 @@ function parseRelatedData (companies) {
   return companies.map((company) => {
     const key = (company.trading_address_1 && company.trading_address_1.length > 0) ? 'trading' : 'registered'
     let address = getFormattedAddress(company, key)
-
+    const url = getViewCompanyLink(company)
     return {
-      name: `<a href="/company/company_company/${company.id}">${company.alias || company.name}</a>`,
+      name: `<a href="${url}">${company.alias || company.name}</a>`,
       address
     }
   })

--- a/src/services/companyservice.js
+++ b/src/services/companyservice.js
@@ -99,4 +99,16 @@ function getCompanyForSource (token, id, source) {
   })
 }
 
-module.exports = { getInflatedDitCompany, getCompanyForSource }
+/**
+ * Pass an API formatted company record in and return a url to view that company
+ * depending on it's type
+ *
+ * @param {Object} company
+ *
+ * @returns {string} url
+ */
+function getViewCompanyLink (company) {
+  return `/company/company_company/${company.id}/details`
+}
+
+module.exports = { getInflatedDitCompany, getCompanyForSource, getViewCompanyLink }

--- a/src/services/dashboardservice.js
+++ b/src/services/dashboardservice.js
@@ -1,5 +1,6 @@
 const authorisedRequest = require('../lib/authorisedrequest')
 const config = require('../config')
+const { getViewCompanyLink } = require('./companyservice')
 
 function mapContacts (contacts) {
   if (contacts && (typeof contacts.map) === 'function') {
@@ -9,7 +10,7 @@ function mapContacts (contacts) {
         name: `${contact.first_name} ${contact.last_name}`,
         id: contact.id,
         company: {
-          url: `/company/company_company/${contact.company.id}/details`,
+          url: getViewCompanyLink(contact.company),
           name: contact.company.name,
           id: contact.company.id
         }
@@ -30,7 +31,7 @@ function mapInteractions (interactions) {
         subject: interaction.subject,
         company: {
           name: company ? company.name : null,
-          url: company ? `/company/company_company/${company.id}/details` : null
+          url: company ? getViewCompanyLink(company) : null
         }
       }
     })

--- a/src/services/interactionformattingservice.js
+++ b/src/services/interactionformattingservice.js
@@ -1,6 +1,8 @@
 const {formatLongDate} = require('../lib/date')
 const {newlineToBr, getContactLink} = require('../lib/textformatting')
 const {getPropertyName} = require('../lib/propertyhelpers')
+const {getViewCompanyLink} = require('../services/companyservice')
+
 /**
  * Returns an interaction formatted for display in the interaction detail
  * page. Compatible with key value table macro
@@ -9,8 +11,9 @@ const {getPropertyName} = require('../lib/propertyhelpers')
  * @returns {Object} A formatted service delivery or interaction
  */
 function getDisplayInteraction (interaction) {
+  const companyUrl = getViewCompanyLink(interaction.company)
   const result = {
-    company: `<a href="/company/company_company/${interaction.company.id}/details">${interaction.company.name}</a>`,
+    company: `<a href="${companyUrl}">${interaction.company.name}</a>`,
     interaction_type: interaction.interaction_type.name,
     subject: interaction.subject,
     notes: newlineToBr(interaction.notes),

--- a/src/services/servicedeliveryformattingservice.js
+++ b/src/services/servicedeliveryformattingservice.js
@@ -1,14 +1,15 @@
 const {formatLongDate} = require('../lib/date')
 const {newlineToBr, getContactLink} = require('../lib/textformatting')
 const {getPropertyName} = require('../lib/propertyhelpers')
+const {getViewCompanyLink} = require('../services/companyservice')
 
 function getDisplayServiceDelivery (serviceDelivery) {
   if (!serviceDelivery) {
     return null
   }
-
+  const companyUrl = getViewCompanyLink(serviceDelivery.company)
   const result = {
-    company: `<a href="/company/company_company/${serviceDelivery.company.id}/details">${serviceDelivery.company.name}</a>`,
+    company: `<a href="${companyUrl}">${serviceDelivery.company.name}</a>`,
     dit_team: getPropertyName(serviceDelivery, 'dit_team'),
     service: getPropertyName(serviceDelivery, 'service'),
     status: getPropertyName(serviceDelivery, 'status'),

--- a/src/views/company/index.html
+++ b/src/views/company/index.html
@@ -20,12 +20,12 @@
   <div class="left-nav">
     <nav>
       <a class="{% if tab == 'details' %}active{% endif %}" href="{{companyUrl}}">Company details</a>
-      <a class="{% if tab == 'hierarchy' %}active{% endif %}" href="/company/{{source}}/{{id}}/details">Company hierarchy</a>
+      <a class="{% if tab == 'hierarchy' %}active{% endif %}" href="">Company hierarchy</a>
       <a class="{% if tab == 'contacts' %}active{% endif %}" href="/company/{{source}}/{{id}}/contacts">Contacts</a>
       <a class="{% if tab == 'interactions' %}active{% endif %}" href="/company/{{source}}/{{id}}/interactions">Interactions</a>
-      <a class="{% if tab == 'documents' %}active{% endif %}" href="/company/{{source}}/{{id}}/contacts">Documents</a>
-      <a class="{% if tab == 'exports' %}active{% endif %}" href="/company/{{source}}/{{id}}/export">Export</a>
-      <a class="{% if tab == 'investment' %}active{% endif %}" href="/company/{{source}}/{{id}}/contacts">Investment</a>
+      <a class="{% if tab == 'documents' %}active{% endif %}" href="">Documents</a>
+      <a class="{% if tab == 'exports' %}active{% endif %}" href="">Export</a>
+      <a class="{% if tab == 'investment' %}active{% endif %}" href="">Investment</a>
     </nav>
   </div>
   <div class="right-content">

--- a/src/views/company/index.html
+++ b/src/views/company/index.html
@@ -19,7 +19,7 @@
 <div class="left-nav-container">
   <div class="left-nav">
     <nav>
-      <a class="{% if tab == 'details' %}active{% endif %}" href="/company/{{source}}/{{id}}/details">Company details</a>
+      <a class="{% if tab == 'details' %}active{% endif %}" href="{{companyUrl}}">Company details</a>
       <a class="{% if tab == 'hierarchy' %}active{% endif %}" href="/company/{{source}}/{{id}}/details">Company hierarchy</a>
       <a class="{% if tab == 'contacts' %}active{% endif %}" href="/company/{{source}}/{{id}}/contacts">Contacts</a>
       <a class="{% if tab == 'interactions' %}active{% endif %}" href="/company/{{source}}/{{id}}/interactions">Interactions</a>

--- a/src/views/contact/edit.html
+++ b/src/views/contact/edit.html
@@ -22,7 +22,7 @@
 
         <div class='form-group'>
           <div class='form-label-bold'>Company</div>
-          <a href="/company/company_company/{{contact.company.id}}/details">{{ contact.company.name }}</a>
+          <a href="{{companyUrl}}">{{ contact.company.name }}</a>
         </div>
 
         {{ trade.textbox("first_name", label="First name", value=formData.first_name, error=errors.first_name) }}

--- a/src/views/contact/index.html
+++ b/src/views/contact/index.html
@@ -4,7 +4,7 @@
 {% block main %}
 <h1 class="page-heading">
   {{contact.first_name}} {{contact.last_name}} {% if contact.primary == true %}{{trade.statusbadge('Primary', variation="fuschia")}}{% endif %}
-  <span class="post-header"><a href="/company/company_company/{{contact.company.id}}/details">{{contact.company.name}}</a></span>
+  <span class="post-header"><a href="{{companyUrl}}">{{contact.company.name}}</a></span>
 </h1>
 
 <div class="left-nav-container">

--- a/src/views/interaction/servicedelivery-edit.html
+++ b/src/views/interaction/servicedelivery-edit.html
@@ -27,7 +27,7 @@
 
     <div class='form-group'>
       <div class='form-label-bold'>Company</div>
-      <a href="/company/company_company/{{serviceDelivery.company.id}}">{{ serviceDelivery.company.name }}</a>
+      <a href="{{companyUrl}}">{{ serviceDelivery.company.name }}</a>
     </div>
 
     <div class='form-group'>

--- a/src/views/search/result.html
+++ b/src/views/search/result.html
@@ -3,7 +3,7 @@
 
   <li class="results-list__result result-list__ch" data_name="{{ result.name }}">
     <h3 class="result-title">
-      <a href="/company/{{ type }}/{{ id }}/details?term={{ term }}">{{result.name | highlightTerm(term) | safe}}</a>
+      <a href="/search/viewcompanyresult/{{ type }}/{{ id }}">{{result.name | highlightTerm(term) | safe}}</a>
     </h3>
 
     {% if result.company_number %}

--- a/src/views/search/result.html
+++ b/src/views/search/result.html
@@ -3,7 +3,7 @@
 
   <li class="results-list__result result-list__ch" data_name="{{ result.name }}">
     <h3 class="result-title">
-      <a href="/search/viewcompanyresult/{{ type }}/{{ id }}">{{result.name | highlightTerm(term) | safe}}</a>
+      <a href="/viewcompanyresult/{{ type }}/{{ id }}">{{result.name | highlightTerm(term) | safe}}</a>
     </h3>
 
     {% if result.company_number %}

--- a/test/services/dashboardservice.test.js
+++ b/test/services/dashboardservice.test.js
@@ -1,3 +1,4 @@
+/* globals expect: true, describe: true, it: true */
 const proxyquire = require('proxyquire')
 
 describe('Dashboard service', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,13 +1325,13 @@ debug@2.6.0:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1, debug@^2.1.1:
+debug@2.6.1, debug@^2.1.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
 
-debug@2.6.3, debug@^2.2.0, debug@^2.6.3:
+debug@2.6.3, debug@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:


### PR DESCRIPTION
Currently all links to company use /company/company_company which is coded into html or hard coded.

In upcoming PR's the url's for a company will change to one dependant on it's type. Using a function to do this lets us do this gradually without breaking things.