### PR TITLE
Always send address fields when saving a contact

### DIFF
--- a/src/repositorys/contactrepository.js
+++ b/src/repositorys/contactrepository.js
@@ -13,17 +13,6 @@ function saveContact (token, contact) {
     body: contact
   }
 
-  if (contact.address_same_as_company) {
-    delete contact.address_1
-    delete contact.address_2
-    delete contact.address_3
-    delete contact.address_4
-    delete contact.address_town
-    delete contact.address_county
-    delete contact.address_country
-    delete contact.address_postcode
-  }
-
   if (contact.id && contact.id.length > 0) {
     // update
     options.url = `${config.apiRoot}/contact/${contact.id}/`


### PR DESCRIPTION
This fixes the problem of not being able to change 'Is the contact's address the same as the company address?' to 'Yes' for an existing contact.

The address is cleared out here, so there doesn't seem to be a reason to remove them from the request: https://github.com/uktrade/data-hub-fe-beta2/blob/b8088c521d7640894a53072938cb66c7c9c02302/src/javascripts/contactedit.js#L18-L18