### PR TITLE
docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3"
 services:
+  redis:
+    image: redis
   datahub-invest-fe:
     build:
       context: .
@@ -15,3 +17,5 @@ services:
       - ./test:/usr/src/app/test
       - ./build:/usr/src/app/build
     command: npm run develop
+    links:
+      - redis


### PR DESCRIPTION
I have added a bog standard redis image to the docker compose file and then added this as a link in the datahub-invest-fe app. Feels like this would simplify setup. Unless @ztolley there is a reason why this hasn't been done previously? If this needs to be overridden all `REDIS_*` envs still function as before.

I will also raise a PR to update the README.md with this info once #46 has been merged