### PR TITLE
Environment Variables used in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ To start the server just:
 
     docker-compose up
 
-The server starts in developer mode, which means that when you make local changes it will auto-compile
-sass or javavscript, and will restart nodejs when server side changes are made.
+The server starts in developer mode, which means that when you make local changes it will auto-compile 
+sass or javavscript, and will restart nodejs when server side changes are made. A container with redis will also start, this is linked to the data hub container. 
 
 You can access the server on port 3000, [http://localhost:3000](http://localhost:3000). You can also run
-a remote debug session over port 5858 if using webstorm or Visual Studio Code
+a remote debug session over port 5858 if using webstorm/Intellij or Visual Studio Code
+
+#### Environment Variables
+Docker Compose [supports declaring default environment variables](https://docs.docker.com/compose/environment-variables/#the-envfile-configuration-option) in an environment file. If you wish to send through environment variables to the docker containers please add them into the `.env` file in the projects root. 
 
 ### Native install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   redis:
     image: redis
   datahub-invest-fe:
+    env_file:
+     - .env
     build:
       context: .
     ports:
@@ -10,8 +12,10 @@ services:
       - 5858:5858
       - 9229:9229
     environment:
-     - POSTCODE_KEY
      - API_ROOT
+     - API_CLIENT_ID
+     - API_CLIENT_SECRET
+     - POSTCODE_KEY
     volumes:
       - ./src:/usr/src/app/src
       - ./test:/usr/src/app/test


### PR DESCRIPTION
The current `docker-compose` file doesn't run the app due to the necessary environment variables not being exposed. This work:

- exposes just the required environment variables to the containers provided via `docker-compose` in the `environment` property
- documents how to send through other environment variables to `docker-compose` containers via the `env_file` property and the `.env` file
- explains that you don't need to have a separate `redis` running if you work via `docker-compose`

This will work well with the work in #46 once this is merged in
