### PR TITLE
add git pre commit hooks for linting and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Lint both SASS and JS to make sure it conforms to rules:
 yarn run lint
 ```
 
+Manually setup github pre-commit hooks
+> Please note this also automatically runs as a `postinstall` npm script
+```
+npm run setup:githooks
+```
+
 ## Making changes
 
 See the [contributing guide](./CONTRIBUTING.md).

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+PATH="/usr/local/bin:$PATH"
+
+set -o errexit
+unset GIT_DIR
+
+git diff --cached --name-only | if grep -E "src/sass/.*\.scss"
+then
+npm run lint:sass
+fi
+sass=$?
+
+git diff --cached --name-only | if grep -E ".*\.js$"
+then
+npm run lint:js && npm test
+fi
+javascript=$?
+
+[ ${sass} -ne 0 ] || [ ${javascript} -ne 0 ] && exit 1
+exit 0

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lint:sass": "sass-lint -c .sass-lint.yml 'src/**/*.scss' -v -q",
     "develop": "parallel sass:watch js:client:watch js:server:watch",
     "client:watch": "parallel sass:watch js:client:watch",
+    "postinstall": "npm run setup:scripts && npm run setup:githooks",
     "js": "npm run js:client",
     "js:client": "webpack",
     "js:client:watch": "webpack --watch",
@@ -72,6 +73,8 @@
     "sass:watch": "npm run sass && npm run sass -- -r -w",
     "sass:compile": "npm run sass -- -x --output-style compressed",
     "sync": "browser-sync start --proxy http://localhost:3000 --files build/css/*.css build/javascripts/*.js",
+    "setup:githooks": "scripts/git-hooks.sh",
+    "setup:scripts": "chmod -R +x scripts",
     "circle": "yarn standard && yarn nyc --reporter=html --reporter=text mocha --require test/common.js --ui bdd test/**/*.test.js && yarn sass && yarn js",
     "heroku-postbuild": "npm rebuild node-sass && yarn sass && yarn js"
   },

--- a/scripts/git-hooks.sh
+++ b/scripts/git-hooks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+GIT_HOOKS=".git/hooks"
+PROJECT_HOOKS="git-hooks"
+
+if [ -d ${GIT_HOOKS} ]; then
+echo "---- Installing project git hooks ----"
+
+chmod -R +x ${PROJECT_HOOKS} && \
+cp -aR ${PROJECT_HOOKS}/* ${GIT_HOOKS}
+fi


### PR DESCRIPTION
This work adds the ability to provide project git hooks for this repo by placing them within the `/git-hooks` folder. I have also added a `pre-commit` hook that:
- Will run `npm run lint:sass` for any changed `src/sass/.*\.scss` files
- Will run `npm run lint:js && npm test` for any change `.*\.js` files

This work also has introduced a`/scripts` folder which is a place to put any large npm scripts

## Summary of Work
- add a `git-hooks` folder containing a `pre-commit` file
- document manual use of `npm run setup:githooks`
- add npm script `setup:scripts` that makes files within `/scripts` executable
- add `postinstall` task which runs `npm run setup:scripts` & `npm run setup:githooks`