### PR TITLE
generic error logging and tests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,10 @@
 const port = process.env.PORT || 3000
-const defaultLogLevel = (process.env.NODE_ENV === 'development') ? 'debug' : 'error'
+const isDev = (process.env.NODE_ENV === 'development')
+const defaultLogLevel = isDev ? 'debug' : 'error'
 
 module.exports = {
   env: process.env.NODE_ENV,
+  isDev,
   port,
   apiRoot: process.env.API_ROOT || 'http://localhost:8000',
   api: {

--- a/src/middleware/errors.js
+++ b/src/middleware/errors.js
@@ -1,0 +1,34 @@
+const config = require('../config')
+const winston = require('winston')
+
+function notFound (req, res, next) {
+  const error = new Error('Not Found')
+  error.status = 404
+
+  next(error)
+}
+
+function catchAll (error, req, res, next) {
+  const statusCode = error.status = (error.status || 500)
+  const statusMessage = statusCode === 404
+    ? 'Sorry we couldn\'t find that page!'
+    : 'Sorry something has gone wrong!'
+
+  if (res.headersSent) {
+    return next(error)
+  }
+
+  winston[statusCode === 500 ? 'error' : 'info'](error)
+
+  res.status(statusCode)
+    .render('errors/index', {
+      statusCode,
+      statusMessage,
+      devErrorDetail: config.isDev && error
+    })
+}
+
+module.exports = {
+  notFound,
+  catchAll
+}

--- a/src/middleware/force-https.js
+++ b/src/middleware/force-https.js
@@ -1,6 +1,5 @@
+const { isDev } = require('../config')
 const winston = require('winston')
-
-const isDev = process.env.NODE_ENV === 'development'
 
 module.exports = function forceHttps (req, res, next) {
   try {

--- a/src/sass/_pre.scss
+++ b/src/sass/_pre.scss
@@ -1,0 +1,5 @@
+.horizontal-scroll {
+  overflow: auto;
+  word-wrap: normal;
+  white-space: pre;
+}

--- a/src/sass/application.scss
+++ b/src/sass/application.scss
@@ -16,6 +16,7 @@ $images-dir: '/images/';
 @import 'shame';
 @import 'splitheader';
 @import 'tables';
+@import 'pre';
 
 .table--readonly {
   border-left-width: 5px;

--- a/src/server.js
+++ b/src/server.js
@@ -37,9 +37,9 @@ const interactionEditController = require('./controllers/interaction-edit.contro
 const serviceDeliveryController = require('./controllers/service-delivery.controller')
 const supportController = require('./controllers/support.controller')
 
+const isDev = config.isDev
 const app = express()
 app.disable('x-powered-by')
-const isDev = app.get('env') === 'development'
 winston.level = config.logLevel
 
 const RedisStore = redisCrypto(session)

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,7 @@ const metadata = require('./repos/metadata.repo')
 const user = require('./middleware/user')
 const auth = require('./middleware/auth')
 const csrf = require('./middleware/csrf')
+const errors = require('./middleware/errors')
 
 const apiController = require('./controllers/api.controller')
 const contactController = require('./controllers/contact.controller')
@@ -152,6 +153,9 @@ app.use(searchController.router)
 app.use(apiController.router)
 app.get('/', indexController)
 app.use('/ping.xml', pingdomController.get)
+
+app.use(errors.notFound)
+app.use(errors.catchAll)
 
 metadata.fetchAll((errors) => {
   if (errors) {

--- a/src/views/error.njk
+++ b/src/views/error.njk
@@ -1,5 +1,0 @@
-{% extends "layouts/ukti.njk" %}
-
-{% block main %}
-<h1 class="heading-medium error">{{error}}</h1>
-{% endblock %}

--- a/src/views/errors/index.njk
+++ b/src/views/errors/index.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/ukti.njk" %}
+
+{% block main %}
+  <h1 class="heading-medium error">{{ statusCode }}</h1>
+  <p>{{ statusMessage }}</p>
+
+  {% if devErrorDetail %}
+    <ul>
+      <li>{{ devErrorDetail.message }}</li>
+      <li><pre class="horizontal-scroll">{{ devErrorDetail.stack }}</pre></li>
+    </ul>
+  {% endif %}
+{% endblock %}

--- a/test/middleware/errors.test.js
+++ b/test/middleware/errors.test.js
@@ -1,0 +1,153 @@
+const proxyquire = require('proxyquire')
+const winston = require('winston')
+
+const errorCode404 = 404
+const errorCode500 = 500
+const isDev = true
+const errorsStub = (isDev) => {
+  return proxyquire('../../src/middleware/errors', {
+    '../config': {
+      isDev
+    }
+  })
+}
+
+let winstonErrorStub
+let winstonInfoStub
+
+before(function () {
+  winstonErrorStub = sinon.stub(winston, 'error')
+  winstonInfoStub = sinon.stub(winston, 'info')
+})
+
+after(function () {
+  winston.error.restore()
+  winston.info.restore()
+})
+
+describe('Error Middleware Test', function () {
+  describe('notFound method', function () {
+    it('should log a 404 and drop through to next middleware', function (done) {
+      const nextSpy = sinon.spy()
+
+      errorsStub(isDev).notFound(null, null, nextSpy)
+
+      expect(nextSpy.calledOnce).to.be.true
+      expect(nextSpy.args[0][0] instanceof Error).to.be.true
+      expect(nextSpy.args[0][0].message).to.equal('Not Found')
+      expect(nextSpy.args[0][0].status).to.equal(404)
+      done()
+    })
+  })
+
+  describe('catchAll method', function () {
+    it('should log a 404 and render response', function (done) {
+      const nextSpy = sinon.spy()
+      const responseRenderSpy = sinon.spy()
+      const mockResponse = {
+        status: () => {
+          return {
+            render: responseRenderSpy
+          }
+        },
+        headersSent: false
+      }
+      const responseStatusSpy = sinon.spy(mockResponse, 'status')
+      const error = new Error(`mock ${errorCode404} error`)
+
+      error.status = errorCode404
+      errorsStub(isDev).catchAll(error, null, mockResponse, nextSpy)
+
+      expect(responseStatusSpy.calledOnce).to.be.true
+      expect(responseStatusSpy.args[0][0]).to.equal(errorCode404)
+      expect(responseRenderSpy.calledOnce).to.be.true
+      expect(responseRenderSpy.args[0][0]).to.equal('errors/index')
+      expect(responseRenderSpy.args[0][1]).to.eql({
+        'devErrorDetail': error,
+        'statusCode': errorCode404,
+        'statusMessage': 'Sorry we couldn\'t find that page!'
+      })
+      expect(winstonInfoStub.args[0][0] instanceof Error).to.be.true
+      expect(winstonInfoStub.args[0][0].message).to.equal(`mock ${errorCode404} error`)
+      expect(winstonInfoStub.args[0][0].status).to.equal(errorCode404)
+      done()
+    })
+
+    it('should log a 500 and render response', function (done) {
+      const nextSpy = sinon.spy()
+      const responseRenderSpy = sinon.spy()
+      const mockResponse = {
+        status: () => {
+          return {
+            render: responseRenderSpy
+          }
+        },
+        headersSent: false
+      }
+      const responseStatusSpy = sinon.spy(mockResponse, 'status')
+      const error = new Error(`mock ${errorCode500} error`)
+
+      errorsStub(isDev).catchAll(error, null, mockResponse, nextSpy)
+
+      expect(responseStatusSpy.calledOnce).to.be.true
+      expect(responseStatusSpy.args[0][0]).to.equal(errorCode500)
+      expect(responseRenderSpy.calledOnce).to.be.true
+      expect(responseRenderSpy.args[0][0]).to.equal('errors/index')
+      expect(responseRenderSpy.args[0][1]).to.eql({
+        'devErrorDetail': error,
+        'statusCode': errorCode500,
+        'statusMessage': 'Sorry something has gone wrong!'
+      })
+      expect(winstonErrorStub.args[0][0] instanceof Error).to.be.true
+      expect(winstonErrorStub.args[0][0].message).to.equal(`mock ${errorCode500} error`)
+      expect(winstonErrorStub.args[0][0].status).to.equal(errorCode500)
+      done()
+    })
+
+    it('should log a 500 and render response without error information', function (done) {
+      const nextSpy = sinon.spy()
+      const responseRenderSpy = sinon.spy()
+      const mockResponse = {
+        status: () => {
+          return {
+            render: responseRenderSpy
+          }
+        },
+        headersSent: false
+      }
+      const responseStatusSpy = sinon.spy(mockResponse, 'status')
+      const error = new Error(`mock ${errorCode500} error`)
+
+      errorsStub(!isDev).catchAll(error, null, mockResponse, nextSpy)
+
+      expect(responseStatusSpy.calledOnce).to.be.true
+      expect(responseStatusSpy.args[0][0]).to.equal(errorCode500)
+      expect(responseRenderSpy.calledOnce).to.be.true
+      expect(responseRenderSpy.args[0][0]).to.equal('errors/index')
+      expect(responseRenderSpy.args[0][1]).to.eql({
+        'devErrorDetail': false,
+        'statusCode': errorCode500,
+        'statusMessage': 'Sorry something has gone wrong!'
+      })
+      expect(winstonErrorStub.args[0][0] instanceof Error).to.be.true
+      expect(winstonErrorStub.args[0][0].message).to.equal(`mock ${errorCode500} error`)
+      expect(winstonErrorStub.args[0][0].status).to.equal(errorCode500)
+      done()
+    })
+
+    it('should drop through to next middleware as headers have already been sent', function (done) {
+      const nextSpy = sinon.spy()
+      const mockResponse = {
+        headersSent: true
+      }
+      const error = new Error('mock headers sent error')
+
+      errorsStub(isDev).catchAll(error, null, mockResponse, nextSpy)
+
+      expect(nextSpy.args[0][0] instanceof Error).to.be.true
+      expect(nextSpy.args[0][0].message).to.equal('mock headers sent error')
+      expect(nextSpy.args[0][0].status).to.equal(errorCode500)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This work is the first cut at generic error logging for the application. 

### 404
If no route is found it will drop through to the `notFound` middleware, then the `catchAll` middleware and will serve a `404` page.

### !404
In your controller you can now call `next()` with an instantiated `Error` object as the first argument and it will drop through to the `catchAll` middleware. By providing a value to the `error.status` property on the Error object you can set the response status, otherwise without a `.status` value this will default to `500`

```
.catch(next)
```

the stack trace will now show only in the browser when in **development** mode
![screencapture-localhost-3000-dfdfd-1495032660523](https://cloud.githubusercontent.com/assets/2305016/26160335/e32f5c04-3b18-11e7-8b93-637e50f78d1c.png)



## Of Note
- winston will log `error` for `500's` and `info` for anything else.
- The copy/humanised error messages are currently just placeholder copy
- Its worth have a read of the [expressjs error-handling docs](https://expressjs.com/en/guide/error-handling.html)

### Screenshots
#### 404
![404](https://cloud.githubusercontent.com/assets/2305016/26116009/a03712d0-3a59-11e7-8993-f567661f2357.gif)

#### 500
![screen shot 2017-05-16 at 17 02 40](https://cloud.githubusercontent.com/assets/2305016/26116010/a03b4422-3a59-11e7-8b74-c4279908119e.png)
