### PR TITLE
Add support for including components using a nunjucks extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ yarn run lint
 
 See the [contributing guide](./CONTRIBUTING.md).
 
+## Components
+
+This app includes support for including components using a custom [nunjucks
+tag](https://mozilla.github.io/nunjucks/api.html#custom-tags). This method
+allows components to be available in all layouts, views, includes and macros
+and allows each component to be a separating entity which makes maintaining
+and testing them easier.
+
+To include a component with its default state or one that expects no data:
+
+```njk
+{% component 'person' %}
+```
+
+To include a component and pass data to it:
+
+```njk
+{% component 'person', {
+  name: 'Barry',
+  age: '55'
+} %}
+```
+
 ## Deployment
 
 Commits to `develop` are automatically deployed to a heroku instance. Pull

--- a/config/nunjucks.js
+++ b/config/nunjucks.js
@@ -1,0 +1,63 @@
+const nunjucks = require('nunjucks')
+const winston = require('winston')
+
+const COMPONENTS_PATH = '_components/' // relative to views path
+const COMPONENT_EXT = 'njk'
+
+function ComponentExtension (env) {
+  this.tags = ['component']
+
+  this.parse = function parse (parser, nodes) {
+    const tok = parser.nextToken()
+    const args = parser.parseSignature(null, true)
+
+    parser.advanceAfterBlockEnd(tok.value)
+
+    return new nodes.CallExtension(this, 'run', args)
+  }
+
+  this.run = function run (context, name, locals = {}) {
+    let result = ''
+
+    try {
+      result = env.render(`${COMPONENTS_PATH}${name}.${COMPONENT_EXT}`, locals)
+    } catch (e) {
+      if (e.message.includes('template not found')) {
+        result = `Component '${name}' does not exist`
+      } else {
+        result = e.message
+      }
+
+      winston.error(result)
+    }
+
+    return new nunjucks.runtime.SafeString(result)
+  }
+}
+
+module.exports = (app, config) => {
+  const env = nunjucks.configure([
+    `${config.root}/src/views`,
+    `${config.root}/node_modules/@uktrade/trade_elements/dist/nunjucks`
+  ], {
+    autoescape: true,
+    express: app,
+    watch: config.isDev
+  })
+
+  // Custom filters
+  const filters = require(`@uktrade/trade_elements/dist/nunjucks/filters`)
+
+  filters.stringify = JSON.stringify
+
+  Object.keys(filters).forEach((filterName) => {
+    env.addFilter(filterName, filters[filterName])
+  })
+
+  // Custom extensions
+  env.addExtension('ComponentExtension', new ComponentExtension(env))
+
+  // Global variables
+
+  return env
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,11 @@
+const path = require('path')
+
 const port = process.env.PORT || 3000
 const isDev = (process.env.NODE_ENV !== 'production')
 const defaultLogLevel = isDev ? 'debug' : 'error'
 
 module.exports = {
+  root: path.normalize(`${__dirname}/..`),
   env: process.env.NODE_ENV,
   isDev,
   port,

--- a/src/server.js
+++ b/src/server.js
@@ -4,15 +4,14 @@ const compression = require('compression')
 const config = require('./config')
 const express = require('express')
 const flash = require('connect-flash')
-const nunjucks = require('nunjucks')
 const redis = require('redis')
 const redisCrypto = require('connect-redis-crypto')
 const session = require('express-session')
 const url = require('url')
 const winston = require('winston')
 
+const nunjucks = require('../config/nunjucks')
 const datahubFlash = require('./middleware/flash')
-const filters = require('@uktrade/trade_elements/dist/nunjucks/filters')
 const forceHttps = require('./middleware/force-https')
 const headers = require('./middleware/headers')
 const locals = require('./middleware/locals')
@@ -97,18 +96,8 @@ app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))
 
 app.use(compression())
 
-filters.stringify = JSON.stringify
-
 app.set('view engine', 'njk')
-const nunenv = nunjucks.configure([`${__dirname}/views`, `${__dirname}/../node_modules/@uktrade/trade_elements/dist/nunjucks`], {
-  autoescape: true,
-  express: app,
-  watch: isDev
-})
-
-Object.keys(filters).forEach((filterName) => {
-  nunenv.addFilter(filterName, filters[filterName])
-})
+nunjucks(app, config)
 
 // Static files
 app.use('/javascripts', express.static(`${__dirname}/../build/javascripts`))


### PR DESCRIPTION
This adds the ability to separate components into their own `.njk` files and call them from any view, include or macro using a [custom nunjucks tag](https://mozilla.github.io/nunjucks/api.html#custom-tags).

Custom tags also allow easier reading of view files. It clearly shows a component is being loaded and avoids confusion with nunjucks' double brace syntax which could be calling a global function/variable, a macro or a local variable.

It also includes moving the nunjucks specific config to its own file to increase maintainability and reduce the configuration happening in `server.js`.

## Including components

To include a component with its default state or that expects no data:

```njk
{% component 'person' %}
```

To include a component with data:

```njk
{% component 'person', {
  name: 'Barry',
  age: '55'
} %}
```