### PR TITLE
Move dotenv dependency to deps rather than devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compression": "^1.6.2",
     "connect-flash": "0.1.1",
     "connect-redis-crypto": "3.1.1",
+    "dotenv": "^4.0.0",
     "eslint": "^3.17.0",
     "express": "^4.14.0",
     "express-session": "^1.14.1",
@@ -87,7 +88,6 @@
     "node": "6.10.2"
   },
   "devDependencies": {
-    "dotenv": "^4.0.0",
     "pre-commit": "^1.2.2"
   }
 }


### PR DESCRIPTION
The dotenv package is being included in the main `server.js` file
and is therefore required in production too.