### PR TITLE
fix circle ci integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ reports
 .env
 npm*.log
 stats.json
+
+.nyc_output
+coverage
+test-results.xml

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,6 @@ test:
   override:
     - yarn circle:
         environment:
-          MOCHA_FILE: $CIRCLE_TEST_REPORTS/junit/test-results.xml
+          MOCHA_FILE: $CIRCLE_TEST_REPORTS/test-results.xml
+  post:
+     - cp -R coverage $CIRCLE_ARTIFACTS

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jsdom": "^10.1.0",
     "lodash": "^4.16.4",
     "mocha": "^3.0.2",
-    "mocha-junit-reporter": "^1.12.0",
     "mocha-multi": "^0.9.1",
     "moment": "^2.17.1",
     "nock": "^9.0.13",
@@ -57,7 +56,7 @@
     "clean": "rm -rf build",
     "start": "node --use-strict src/server.js",
     "build": "npm run clean && npm run sass:compile && npm run js",
-    "test": "mocha --require test/common.js --ui bdd test/**/*.test.js",
+    "test": "mocha --reporter mocha-circleci-reporter --require test/common.js --ui bdd test/**/*.test.js",
     "test:watch": "npm test -- -w",
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov mocha --require test/common.js --ui bdd test/**/*.test.js",
     "lint": "npm run lint:js && npm run lint:sass",
@@ -76,7 +75,7 @@
     "sass:watch": "npm run sass && npm run sass -- -r -w",
     "sass:compile": "npm run sass -- -x --output-style compressed",
     "sync": "browser-sync start --proxy http://localhost:3000 --files build/css/*.css build/javascripts/*.js",
-    "circle": "npm run lint && nyc --reporter=html --reporter=text npm test && npm run sass && npm run js",
+    "circle": "npm run lint && nyc --reporter=text-summary --reporter=html npm test && npm run sass && npm run js",
     "heroku-postbuild": "npm rebuild node-sass && npm run sass && npm run js"
   },
   "pre-commit": [
@@ -89,6 +88,7 @@
     "node": "6.10.2"
   },
   "devDependencies": {
+    "mocha-circleci-reporter": "0.0.2",
     "pre-commit": "^1.2.2"
   }
 }


### PR DESCRIPTION
Fix circle integration

- show test results in **Test Summary** section in `CircleCi`
- make coverage report available in **Artifacts** section in `CircleCi`

You can see [the code coverage](https://531-83823675-gh.circle-artifacts.com/0/tmp/circle-artifacts.BqnjfA4/coverage/index.html) from the **Artifacts** section.

## Of Note
This is first cut, it feels like we should also be able to see code coverage in the test summary section, even if its just percentages which then click through to the above code report

<img width="1177" alt="screen shot 2017-05-19 at 17 30 10" src="https://cloud.githubusercontent.com/assets/2305016/26257649/651ee5b2-3cb9-11e7-8c6f-0996d565c294.png">


<img width="1183" alt="screen shot 2017-05-19 at 17 31 03" src="https://cloud.githubusercontent.com/assets/2305016/26257661/7284d50e-3cb9-11e7-921e-92636ad2ddbc.png">


<img width="1199" alt="screen shot 2017-05-19 at 17 27 15" src="https://cloud.githubusercontent.com/assets/2305016/26257653/694a8fc4-3cb9-11e7-8c77-4781c2910b4d.png">
