### PR TITLE
Fix JS lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:watch": "npm test -- -w",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:js": "eslint ./test ./src *.js",
-    "lint:js:modified": "CHANGED_FILES=$(git diff --staged --name-only -- '*.js'); if [ $CHANGED_FILES ]; then eslint $CHANGED_FILES; fi",
+    "lint:js:modified": "CHANGED_FILES=$(git diff --staged --name-only -- '*.js'); if [ $CHANGED_FILES ]; then eslint $(echo $CHANGED_FILES); fi",
     "lint:sass": "sass-lint -c .sass-lint.yml 'src/**/*.scss' -v -q",
     "lint:sass:modified": "sass-lint -c .sass-lint.yml $(git diff --staged --name-only -- '*.scss') -v -q",
     "develop": "parallel sass:watch js:client:watch js:server:watch",


### PR DESCRIPTION
Currently the script would only take the first file to lint.
This fix should pass all staged files to linter