### PR TITLE
Remove contact.teams field

### DIFF
--- a/test/controllers/company-contact.controller.test.js
+++ b/test/controllers/company-contact.controller.test.js
@@ -103,8 +103,7 @@ describe('Company contacts controller', function () {
         selectable: true
       },
       advisor: null,
-      address_country: null,
-      teams: []
+      address_country: null
     },
     {
       company,
@@ -139,8 +138,7 @@ describe('Company contacts controller', function () {
         selectable: true
       },
       advisor: null,
-      address_country: null,
-      teams: []
+      address_country: null
     },
     {
       company,
@@ -190,8 +188,7 @@ describe('Company contacts controller', function () {
         selectable: true
       },
       advisor: null,
-      address_country: null,
-      teams: []
+      address_country: null
     }]
   })
 

--- a/test/controllers/contact-edit.controller.test.js
+++ b/test/controllers/contact-edit.controller.test.js
@@ -85,7 +85,6 @@ describe('Contact controller, edit', function () {
           },
           advisor: null,
           address_country: null,
-          teams: [],
           company
         }
         req = {

--- a/test/controllers/contact.controller.test.js
+++ b/test/controllers/contact.controller.test.js
@@ -48,7 +48,6 @@ describe('Contact controller', function () {
       },
       advisor: null,
       address_country: null,
-      teams: [],
       company: {
         id: '876544',
         name: 'Bank ltd.'

--- a/test/data/simple-contact.js
+++ b/test/data/simple-contact.js
@@ -31,7 +31,6 @@ module.exports = {
   },
   advisor: null,
   address_country: null,
-  teams: [],
   company: {
     id: '555',
     name: 'Fred ltd'

--- a/test/services/contact-form.service.test.js
+++ b/test/services/contact-form.service.test.js
@@ -36,8 +36,6 @@ describe('contact form service', function () {
     beforeEach(function () {
       contact = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
-        teams: [],
-        interactions: [],
         name: 'Zac Baman',
         address_1: '99 N Shore Road',
         address_2: 'Suite 20',

--- a/test/services/contact-formatting.service.test.js
+++ b/test/services/contact-formatting.service.test.js
@@ -36,8 +36,7 @@ describe('Contact formatting service', function () {
         selectable: true
       },
       advisor: null,
-      address_country: null,
-      teams: []
+      address_country: null
     }
   })
   describe('contact details', function () {


### PR DESCRIPTION
`Contact.teams` got removed from the API as it's not useful at the moment, this PR removes it from the test data.