### PR TITLE
refactor and fix for the way doc_type is passed to the search endpoint

### DIFF
--- a/src/controllers/search.controller.js
+++ b/src/controllers/search.controller.js
@@ -7,15 +7,26 @@ const Q = require('q')
 
 const router = express.Router()
 
-function get (req, res, next) {
-  const filters = Object.assign({}, req.query)
-  delete filters.term
-  delete filters.page
+function buildSearchFilters (query) {
+  const docType = query.doc_type
+  const filters = []
 
+  if (docType === 'company') {
+    filters.push('company_company', 'company_companieshousecompany')
+  } else if (docType) {
+    filters.push(docType)
+  }
+
+  return filters
+}
+
+function get (req, res, next) {
   if (!req.query.term || req.query.term.length === 0) {
     res.render('search/facet-search', { result: null, pagination: null, params: req.query })
     return
   }
+
+  const filters = buildSearchFilters(req.query)
 
   searchService.search({
     token: req.session.token,
@@ -25,7 +36,11 @@ function get (req, res, next) {
   })
     .then((result) => {
       const pagination = getPagination(req, result)
-      res.render('search/facet-search', { result, pagination, params: req.query })
+      res.render('search/facet-search', {
+        result,
+        pagination,
+        params: req.query
+      })
     })
     .catch(next)
 }

--- a/src/javascripts/search.js
+++ b/src/javascripts/search.js
@@ -4,7 +4,7 @@ const Facets = require('./facets')
 document.addEventListener(
   'DOMContentLoaded',
   function () {
-    new Facets(document.getElementById('facets'), document.getElementById('result-summary'))
+    new Facets(document.getElementById('facets'))
   },
   false
 )

--- a/src/lib/url-helpers.js
+++ b/src/lib/url-helpers.js
@@ -33,4 +33,18 @@ function getBackLink (params) {
   return null
 }
 
-module.exports = { getQueryParam, getBackLink }
+function buildQueryString (params) {
+  let queryParams = []
+
+  Object.keys(params).forEach((key) => {
+    queryParams.push(`${key}=${params[key]}`)
+  })
+
+  return encodeURI(`?${queryParams.join('&')}`)
+}
+
+module.exports = {
+  getQueryParam,
+  getBackLink,
+  buildQueryString
+}

--- a/src/views/search/facets.njk
+++ b/src/views/search/facets.njk
@@ -8,8 +8,8 @@
           <div class="option-select-label">
             {{ facet }}
             <span class="controls">
-              <span class="clear-filter-button clear-filter-js">clear</span>
-              <i class="collapse-filter collapse-filter-js fa fa-chevron-up"></i>
+              <span class="clear-filter-button js-clear-filter">clear</span>
+              <i class="collapse-filter fa fa-chevron-up js-collapse-filter"></i>
             </span>
           </div>
 

--- a/test/lib/url-helpers.test.js
+++ b/test/lib/url-helpers.test.js
@@ -1,0 +1,23 @@
+const urlHelpers = require(`${root}/src/lib/url-helpers`)
+
+describe('buildQueryString', function () {
+  it('should build the expected query string for a single param', function () {
+    const params = {
+      mock: 'mockParam'
+    }
+    const queryString = urlHelpers.buildQueryString(params)
+
+    expect(queryString).equal(`?mock=${params.mock}`)
+  })
+
+  it('should build the expected query string for multiple params', function () {
+    const params = {
+      mock: 'mockParam',
+      mock1: 'mockParam1',
+      mock2: 'mockParam2'
+    }
+    const queryString = urlHelpers.buildQueryString(params)
+
+    expect(queryString).equal(`?mock=${params.mock}&mock1=${params.mock1}&mock2=${params.mock2}`)
+  })
+})

--- a/test/services/search.service.test.js
+++ b/test/services/search.service.test.js
@@ -5,29 +5,31 @@ const companyMockAPIResponse = require(`${root}/test/data/search-response-compan
 const companiesHousePrivateLtdMockAPIResponse = require(`${root}/test/data/search-response-companies-house-private-ltd`)
 const companiesHousePublicLtdMockAPIResponse = require(`${root}/test/data/search-response-companies-house-public-ltd`)
 
-const facets = {
-  'facets': {
-    'Category': [
-      {
-        'name': 'doc_type',
-        'value': 'company',
-        'label': 'Company',
-        'checked': undefined
-      },
-      {
-        'name': 'doc_type',
-        'value': 'company_contact',
-        'label': 'Contact',
-        'checked': undefined
-      }
-    ]
+function buildFacets (companyChecked, companyContactChecked) {
+  return {
+    'facets': {
+      'Category': [
+        {
+          'name': 'doc_type',
+          'value': 'company',
+          'label': 'Company',
+          'checked': companyChecked
+        },
+        {
+          'name': 'doc_type',
+          'value': 'company_contact',
+          'label': 'Contact',
+          'checked': companyContactChecked
+        }
+      ]
+    }
   }
 }
 
 describe('Search service', function () {
   describe('searchService.search method', function () {
     it('Should return expected format from search method for a company', function () {
-      const expectedResponse = Object.assign(companyMockAPIResponse, facets)
+      const expectedResponse = Object.assign(companyMockAPIResponse, buildFacets(true, false))
 
       nock(config.apiRoot)
         .post('/search/')
@@ -44,7 +46,7 @@ describe('Search service', function () {
     })
 
     it('Should return expected format from search method for a companies house private ltd', function () {
-      const expectedResponse = Object.assign(companiesHousePrivateLtdMockAPIResponse, facets)
+      const expectedResponse = Object.assign(companiesHousePrivateLtdMockAPIResponse, buildFacets(true, false))
 
       nock(config.apiRoot)
         .post('/search/')
@@ -61,7 +63,7 @@ describe('Search service', function () {
     })
 
     it('Should return expected format from search method for a companies house public ltd', function () {
-      const expectedResponse = Object.assign(companiesHousePublicLtdMockAPIResponse, facets)
+      const expectedResponse = Object.assign(companiesHousePublicLtdMockAPIResponse, buildFacets(true, false))
 
       nock(config.apiRoot)
         .post('/search/')
@@ -71,6 +73,23 @@ describe('Search service', function () {
         token: 'token',
         term: 'testTerm',
         filters: ['company_company', 'company_companieshousecompany']
+      })
+        .then((response) => {
+          expect(response).to.deep.equal(expectedResponse)
+        })
+    })
+
+    it('Should return expected format from search method for a company contact', function () {
+      const expectedResponse = Object.assign(companiesHousePublicLtdMockAPIResponse, buildFacets(false, true))
+
+      nock(config.apiRoot)
+        .post('/search/')
+        .reply(200, companiesHousePublicLtdMockAPIResponse)
+
+      searchService.search({
+        token: 'token',
+        term: 'testTerm',
+        filters: ['company_contact']
       })
         .then((response) => {
           expect(response).to.deep.equal(expectedResponse)


### PR DESCRIPTION
The way `doc_type` was being passed to the api `/search` endpoint was causing a 500 error. 
This work fixes that issue and also refactors the server side and client side code around the selection of facets on the `/search` page.

There was also a bug where you could add multiple `doc_type` to the url path this has also been fixed.

## Of Note
@elcct has a pr up on [data-hub-leeloo](https://github.com/uktrade/data-hub-leeloo/pull/212) that:
>It also adds 3 search endpoints for basic and detailed search - specs are available in data-hub-api-spec repository.

Spec information in [search.yml](https://github.com/uktrade/data-hub-api-spec/blob/master/generator/specs/paths/search.yml)

## TODO
Once this has been released we can send `company` and `contact` to the api which means more complexity can be removed from the frontend code:
- The [buildSearchFilters](https://github.com/uktrade/data-hub-fe-beta2/compare/feature/DH-258-refactor-doc_type-passed-to-search?expand=1#diff-b20e67cec3704e32aa6b08c2a7a007cfR10) can be removed. 
- The [buildFacetViewDataObj](https://github.com/uktrade/data-hub-fe-beta2/compare/feature/DH-258-refactor-doc_type-passed-to-search?expand=1#diff-d59a93984165d0bd91213bc63b7cdfa2R60) can be updated.


![search](https://cloud.githubusercontent.com/assets/2305016/26414284/9f48e710-40a6-11e7-8093-0a89a31d8e60.gif)

