### PR TITLE
Remove .only from test file

### DIFF
--- a/test/middleware/errors.test.js
+++ b/test/middleware/errors.test.js
@@ -6,7 +6,7 @@ const errorCode403 = 403
 const errorCode500 = 500
 const isDev = true
 
-describe.only('Error Middleware Test', () => {
+describe('Error Middleware Test', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
     this.winstonErrorStub = this.sandbox.stub(winston, 'error')


### PR DESCRIPTION
A .only slipped into the main branch so this just removes it so the
full test suite runs instead of 1 test