### PR TITLE
Move to Contact API V3

### DIFF
--- a/src/controllers/company-contact.controller.js
+++ b/src/controllers/company-contact.controller.js
@@ -21,7 +21,7 @@ function getContacts (req, res, next) {
       // build the data for the contact table.
       res.locals.contacts = company.contacts
         .filter(contact => !contact.archived)
-        .map(contact => getDisplayCompanyContact(contact))
+        .map(contact => getDisplayCompanyContact(contact, company))
 
       // build the data for the archived contact table.
       res.locals.contactsArchived = company.contacts

--- a/src/controllers/contact-edit.controller.js
+++ b/src/controllers/contact-edit.controller.js
@@ -28,13 +28,16 @@ function editDetails (req, res, next) {
       // or a contact that the user wishes to edit
       // or a new contact for a company
       if (containsFormData(req)) {
+        res.locals.company = res.locals.company
+          ? res.locals.company : yield companyRepository.getDitCompany(token, req.body.company)
         res.locals.formData = req.body
-        res.locals.company = yield companyRepository.getDitCompany(token, req.body.company)
       } else if (res.locals.contact) {
+        res.locals.company = res.locals.company
+          ? res.locals.company : yield companyRepository.getDitCompany(token, res.locals.contact.company.id)
         res.locals.formData = contactFormService.getContactAsFormData(res.locals.contact)
-        res.locals.company = res.locals.contact.company
       } else if (req.query.company) {
-        res.locals.company = yield companyRepository.getDitCompany(token, req.query.company)
+        res.locals.company = res.locals.company
+          ? res.locals.company : yield companyRepository.getDitCompany(token, req.query.company)
         res.locals.formData = { company: res.locals.company.id }
       } else {
         return next('Unable to edit contact')

--- a/src/controllers/contact-edit.controller.js
+++ b/src/controllers/contact-edit.controller.js
@@ -27,20 +27,23 @@ function editDetails (req, res, next) {
       // This can either be data recently posted, to be re-rendered with errors
       // or a contact that the user wishes to edit
       // or a new contact for a company
+      let companyId
+
       if (containsFormData(req)) {
-        res.locals.company = res.locals.company
-          ? res.locals.company : yield companyRepository.getDitCompany(token, req.body.company)
+        companyId = req.body.company
         res.locals.formData = req.body
       } else if (res.locals.contact) {
-        res.locals.company = res.locals.company
-          ? res.locals.company : yield companyRepository.getDitCompany(token, res.locals.contact.company.id)
+        companyId = res.locals.contact.company.id
         res.locals.formData = contactFormService.getContactAsFormData(res.locals.contact)
       } else if (req.query.company) {
-        res.locals.company = res.locals.company
-          ? res.locals.company : yield companyRepository.getDitCompany(token, req.query.company)
-        res.locals.formData = { company: res.locals.company.id }
+        companyId = req.query.company
+        res.locals.formData = { company: req.query.company }
       } else {
         return next('Unable to edit contact')
+      }
+
+      if (!res.locals.company) {
+        res.locals.company = yield companyRepository.getDitCompany(token, companyId)
       }
 
       if (req.params.contactId) {

--- a/src/controllers/contact.controller.js
+++ b/src/controllers/contact.controller.js
@@ -2,6 +2,7 @@ const express = require('express')
 const Q = require('q')
 
 const contactRepository = require('../repos/contact.repo')
+const companyRepository = require('../repos/company.repo')
 const contactFormattingService = require('../services/contact-formatting.service')
 const companyService = require('../services/company.service')
 const { contactDetailsLabels } = require('../labels/contact-labels')
@@ -18,7 +19,8 @@ function getCommon (req, res, next) {
     try {
       res.locals.id = req.params.contactId
       res.locals.contact = yield contactRepository.getContact(req.session.token, req.params.contactId)
-      res.locals.companyUrl = companyService.buildCompanyUrl(res.locals.contact.company)
+      res.locals.company = yield companyRepository.getDitCompany(req.session.token, res.locals.contact.company.id)
+      res.locals.companyUrl = companyService.buildCompanyUrl(res.locals.company)
       res.locals.reasonForArchiveOptions = reasonForArchiveOptions
 
       next()
@@ -31,7 +33,9 @@ function getCommon (req, res, next) {
 function getDetails (req, res, next) {
   try {
     res.locals.tab = 'details'
-    res.locals.contactDetails = contactFormattingService.getDisplayContact(res.locals.contact)
+    res.locals.contactDetails = contactFormattingService.getDisplayContact(
+      res.locals.contact, res.locals.company
+    )
     res.locals.contactDetailsLabels = contactDetailsLabels
     res.locals.contactDetailsDisplayOrder = Object.keys(res.locals.contactDetails)
     res.render('contact/details')

--- a/src/controllers/contact.controller.js
+++ b/src/controllers/contact.controller.js
@@ -34,7 +34,8 @@ function getDetails (req, res, next) {
   try {
     res.locals.tab = 'details'
     res.locals.contactDetails = contactFormattingService.getDisplayContact(
-      res.locals.contact, res.locals.company
+      res.locals.contact,
+      res.locals.company
     )
     res.locals.contactDetailsLabels = contactDetailsLabels
     res.locals.contactDetailsDisplayOrder = Object.keys(res.locals.contactDetails)

--- a/src/lib/property-helpers.js
+++ b/src/lib/property-helpers.js
@@ -82,6 +82,28 @@ function convertYesNoToBoolean (object) {
 }
 
 /**
+* Convert fk relationships from flat to 1-level deep
+*
+* @param {Object} object
+* @param {Array} props
+*/
+function convertNestedObjects (object, props) {
+  const convertedObject = Object.assign({}, object)
+
+  for (const prop of props) {
+    const value = object[prop]
+
+    if (value) {
+      convertedObject[prop] = {
+        id: value
+      }
+    }
+  }
+
+  return convertedObject
+}
+
+/**
  * Determine if an object has a property, and that property is also an object.
  *
  * @param {any} object
@@ -101,4 +123,13 @@ function hasProperty (object, property) {
   object[property] !== null)
 }
 
-module.exports = { getPropertyId, getPropertyName, nullEmptyFields, convertYesNoToBoolean, deleteNulls, hasProperty, hasObjectProperty }
+module.exports = {
+  getPropertyId,
+  getPropertyName,
+  nullEmptyFields,
+  convertYesNoToBoolean,
+  deleteNulls,
+  hasProperty,
+  hasObjectProperty,
+  convertNestedObjects
+}

--- a/src/lib/property-helpers.js
+++ b/src/lib/property-helpers.js
@@ -87,7 +87,7 @@ function convertYesNoToBoolean (object) {
 * @param {Object} object
 * @param {Array} props
 */
-function convertNestedObjects (object, props) {
+function convertNestedObjects (object = {}, props = []) {
   const convertedObject = Object.assign({}, object)
 
   for (const prop of props) {

--- a/src/lib/property-helpers.js
+++ b/src/lib/property-helpers.js
@@ -124,12 +124,12 @@ function hasProperty (object, property) {
 }
 
 module.exports = {
-  getPropertyId,
-  getPropertyName,
-  nullEmptyFields,
+  convertNestedObjects,
   convertYesNoToBoolean,
   deleteNulls,
-  hasProperty,
+  getPropertyId,
+  getPropertyName,
   hasObjectProperty,
-  convertNestedObjects
+  hasProperty,
+  nullEmptyFields
 }

--- a/src/repos/contact.repo.js
+++ b/src/repos/contact.repo.js
@@ -5,7 +5,7 @@ const authorisedRequest = require('../lib/authorised-request')
 const config = require('../config')
 
 function getContact (token, contactId) {
-  return authorisedRequest(token, `${config.apiRoot}/contact/${contactId}/`)
+  return authorisedRequest(token, `${config.apiRoot}/v3/contact/${contactId}`)
 }
 
 function saveContact (token, contact) {
@@ -15,10 +15,10 @@ function saveContact (token, contact) {
 
   if (contact.id && contact.id.length > 0) {
     // update
-    options.url = `${config.apiRoot}/contact/${contact.id}/`
-    options.method = 'PUT'
+    options.url = `${config.apiRoot}/v3/contact/${contact.id}`
+    options.method = 'PATCH'
   } else {
-    options.url = `${config.apiRoot}/contact/`
+    options.url = `${config.apiRoot}/v3/contact`
     options.method = 'POST'
   }
 
@@ -28,14 +28,14 @@ function saveContact (token, contact) {
 function archiveContact (token, contactId, reason) {
   const options = {
     body: { reason },
-    url: `${config.apiRoot}/contact/${contactId}/archive/`,
+    url: `${config.apiRoot}/v3/contact/${contactId}/archive`,
     method: 'POST'
   }
   return authorisedRequest(token, options)
 }
 
 function unarchiveContact (token, contactId) {
-  return authorisedRequest(token, `${config.apiRoot}/contact/${contactId}/unarchive/`)
+  return authorisedRequest(token, `${config.apiRoot}/v3/contact/${contactId}/unarchive`)
 }
 
 function getContactsForCompany (token, companyId) {

--- a/src/repos/interaction.repo.js
+++ b/src/repos/interaction.repo.js
@@ -31,10 +31,11 @@ function saveInteraction (token, interaction) {
  * @return {Array[Object]} Returns a promise that resolves to an array of API interaction objects
  */
 function getInteractionsForContact (token, contactId) {
+  // TODO deal with pagination and move to the interaction API v3 endpoints when they are ready
   return new Promise((resolve) => {
-    authorisedRequest(token, `${config.apiRoot}/contact/${contactId}/`)
+    authorisedRequest(token, `${config.apiRoot}/interaction/?contact_id=${contactId}&limit=100`)
     .then((response) => {
-      resolve(response.interactions)
+      resolve(response.results)
     })
     .catch((error) => {
       winston.info(error)

--- a/src/repos/service-delivery.repo.js
+++ b/src/repos/service-delivery.repo.js
@@ -25,7 +25,7 @@ function getServiceDelivery (token, serviceDeliveryId) {
   })
 }
 
-function getServiceDeliverysForCompany (token, companyId) {
+function getServiceDeliveriesForCompany (token, companyId) {
   return new Promise((resolve) => {
     authorisedRequest(token, `${config.apiRoot}/v2/service-delivery/?company_id=${companyId}`)
     .then((response) => {
@@ -38,7 +38,7 @@ function getServiceDeliverysForCompany (token, companyId) {
   })
 }
 
-function getServiceDeliverysForContact (token, contactId) {
+function getServiceDeliveriesForContact (token, contactId) {
   return new Promise((resolve) => {
     authorisedRequest(token, `${config.apiRoot}/v2/service-delivery/?contact_id=${contactId}`)
     .then((response) => {
@@ -54,6 +54,6 @@ function getServiceDeliverysForContact (token, contactId) {
 module.exports = {
   getServiceDelivery,
   saveServiceDelivery,
-  getServiceDeliverysForCompany,
-  getServiceDeliverysForContact
+  getServiceDeliveriesForCompany,
+  getServiceDeliveriesForContact
 }

--- a/src/services/company.service.js
+++ b/src/services/company.service.js
@@ -21,13 +21,13 @@ function getInflatedDitCompany (token, id) {
       try {
         const advisorHash = {}
         const company = yield companyRepository.getDitCompany(token, id)
-        const serviceDeliverys = yield serviceDeliveryRepository.getServiceDeliverysForCompany(token, company.id)
+        const serviceDeliveries = yield serviceDeliveryRepository.getServiceDeliveriesForCompany(token, company.id)
 
         // Build a list of advisors to lookup
         for (const interaction of company.interactions) {
           advisorHash[interaction.dit_advisor] = true
         }
-        for (const serviceDelivery of serviceDeliverys) {
+        for (const serviceDelivery of serviceDeliveries) {
           advisorHash[serviceDelivery.relationships.dit_advisor.data.id] = true
         }
 
@@ -40,7 +40,7 @@ function getInflatedDitCompany (token, id) {
         const serviceOffers = yield metadataRepository.getServiceOffers(token)
 
         // Parse the service delivery results to expand some of the properties
-        const parsedServiceDeliverys = serviceDeliverys.map((serviceDelivery) => {
+        const parsedServiceDeliveries = serviceDeliveries.map((serviceDelivery) => {
           return Object.assign({}, {id: serviceDelivery.id}, serviceDelivery.attributes, {
             contact: getContactInCompanyObject(company, serviceDelivery.relationships.contact.data.id),
             interaction_type: { id: null, name: 'Service delivery' },
@@ -61,7 +61,7 @@ function getInflatedDitCompany (token, id) {
           })
         })
 
-        const combinedIteractions = [...parsedInteractions, ...parsedServiceDeliverys]
+        const combinedIteractions = [...parsedInteractions, ...parsedServiceDeliveries]
 
         company.interactions = combinedIteractions
         resolve(company)

--- a/src/services/contact-data.service.js
+++ b/src/services/contact-data.service.js
@@ -37,7 +37,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
         const advisorHash = {}
 
         const interactions = yield interactionRepository.getInteractionsForContact(token, contactId)
-        const serviceDeliverys = yield serviceDeliveryRepository.getServiceDeliverysForContact(token, contactId)
+        const serviceDeliveries = yield serviceDeliveryRepository.getServiceDeliveriesForContact(token, contactId)
         const serviceOffers = yield metadataRepository.getServiceOffers(token)
 
         // Build a list of advisors we use in interactions, to help populate service deliveries
@@ -46,7 +46,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
         }
 
         // Go fetch any advisors we haven't got yet for service deliveries
-        for (const serviceDelivery of serviceDeliverys) {
+        for (const serviceDelivery of serviceDeliveries) {
           const dit_advisor = serviceDelivery.relationships.dit_advisor.data.id
           if (!advisorHash[dit_advisor]) {
             advisorHash[dit_advisor] = yield advisorRepository.getAdvisor(token, dit_advisor)
@@ -54,7 +54,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
         }
 
         // Parse the service delivery results into something that can be displayed
-        const parsedServiceDeliverys = serviceDeliverys.map((serviceDelivery) => {
+        const parsedServiceDeliveries = serviceDeliveries.map((serviceDelivery) => {
           return Object.assign({},
             serviceDelivery.attributes,
             {
@@ -66,7 +66,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
             })
         })
 
-        const combinedIteractions = [...interactions, ...parsedServiceDeliverys]
+        const combinedIteractions = [...interactions, ...parsedServiceDeliveries]
         resolve(combinedIteractions)
       } catch (error) {
         winston.error(error)

--- a/src/services/contact-data.service.js
+++ b/src/services/contact-data.service.js
@@ -5,7 +5,6 @@ const advisorRepository = require('../repos/advisor.repo')
 const interactionRepository = require('../repos/interaction.repo')
 const metadataRepository = require('../repos/metadata.repo')
 const serviceDeliveryRepository = require('../repos/service-delivery.repo')
-const interactionDataService = require('./interaction-data.service')
 
 /**
  * Accepts an API contact object and inflates it to pull in related contact data but
@@ -67,17 +66,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
             })
         })
 
-        // Parse the interaction into something that can be displayed
-        const parsedInteractions = interactions.map((interaction) => {
-          return Object.assign({}, interaction, {
-            interaction_type: interactionDataService.getInteractionType(interaction.interaction_type),
-            dit_advisor: advisorHash[interaction.dit_advisor],
-            service: serviceOffers.find((option) => option.id === interaction.service),
-            dit_team: metadataRepository.teams.find((option) => option.id === interaction.dit_team)
-          })
-        })
-
-        const combinedIteractions = [...parsedInteractions, ...parsedServiceDeliverys]
+        const combinedIteractions = [...interactions, ...parsedServiceDeliverys]
         resolve(combinedIteractions)
       } catch (error) {
         winston.error(error)

--- a/src/services/contact-form.service.js
+++ b/src/services/contact-form.service.js
@@ -1,9 +1,9 @@
 const Q = require('q')
 const {
-  getPropertyId,
-  nullEmptyFields,
+  convertNestedObjects,
   convertYesNoToBoolean,
-  convertNestedObjects
+  getPropertyId,
+  nullEmptyFields
 } = require('../lib/property-helpers')
 const contactRepository = require('../repos/contact.repo')
 

--- a/src/services/contact-form.service.js
+++ b/src/services/contact-form.service.js
@@ -1,7 +1,9 @@
 const Q = require('q')
 const {
-  getPropertyId, nullEmptyFields,
-  convertYesNoToBoolean, convertNestedObjects
+  getPropertyId,
+  nullEmptyFields,
+  convertYesNoToBoolean,
+  convertNestedObjects
 } = require('../lib/property-helpers')
 const contactRepository = require('../repos/contact.repo')
 

--- a/src/services/contact-form.service.js
+++ b/src/services/contact-form.service.js
@@ -1,5 +1,8 @@
 const Q = require('q')
-const { getPropertyId, nullEmptyFields, convertYesNoToBoolean } = require('../lib/property-helpers')
+const {
+  getPropertyId, nullEmptyFields,
+  convertYesNoToBoolean, convertNestedObjects
+} = require('../lib/property-helpers')
 const contactRepository = require('../repos/contact.repo')
 
 /**
@@ -56,6 +59,7 @@ function saveContactForm (token, contactForm) {
       try {
         let dataToSave = convertYesNoToBoolean(contactForm)
         dataToSave = nullEmptyFields(dataToSave)
+        dataToSave = convertNestedObjects(dataToSave, ['title', 'company', 'address_country'])
         const savedContact = yield contactRepository.saveContact(token, dataToSave)
         resolve(savedContact)
       } catch (error) {

--- a/src/services/contact-formatting.service.js
+++ b/src/services/contact-formatting.service.js
@@ -3,10 +3,10 @@ const {newlineToBr} = require('../lib/text-formatting')
 const {formatMediumDate} = require('../lib/date')
 const {formatPhone} = require('../lib/phone')
 
-function getContactAddress (contact) {
+function getContactAddress (contact, company) {
   let contactAddress = getFormattedAddress(contact)
   if (!contactAddress) {
-    contactAddress = getFormattedAddress(contact.company, 'trading') || getFormattedAddress(contact.company, 'registered')
+    contactAddress = getFormattedAddress(company, 'trading') || getFormattedAddress(company, 'registered')
   }
   return contactAddress
 }
@@ -15,15 +15,16 @@ function getContactAddress (contact) {
  * Translate a raw contact object into a formatted contact
  * to display on the screen
  * @param {object} contact
+ * @param {object} company
  * @returns {object} displayContact A contact that can be put into a key value table
  *
  */
-function getDisplayContact (contact) {
+function getDisplayContact (contact, company) {
   return {
     job_title: contact.job_title,
     telephone_number: formatPhone(contact.telephone_countrycode, contact.telephone_number),
     email: contact.email,
-    address: getContactAddress(contact),
+    address: getContactAddress(contact, company),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,
     notes: newlineToBr(contact.notes)
@@ -34,9 +35,10 @@ function getDisplayContact (contact) {
  * Format contact details for use in the company screen
  *
  * @param {object} contact
+ * @param {object} company
  * @returns {object} displayContact A contact that can be put into a key value table
  */
-function getDisplayCompanyContact (contact) {
+function getDisplayCompanyContact (contact, company) {
   return {
     id: contact.id,
     url: `/contact/${contact.id}/details`,
@@ -45,7 +47,7 @@ function getDisplayCompanyContact (contact) {
     telephone_number: formatPhone(contact.telephone_countrycode, contact.telephone_number),
     email: contact.email,
     added: formatMediumDate(contact.created_on),
-    address: getContactAddress(contact),
+    address: getContactAddress(contact, company),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,
     notes: newlineToBr(contact.notes)

--- a/test/controllers/contact-edit.controller.test.js
+++ b/test/controllers/contact-edit.controller.test.js
@@ -88,7 +88,7 @@ describe('Contact controller, edit', function () {
         }
         req = {
           session: {
-            token: '1234'
+            token: '321'
           },
           query: {},
           params: {
@@ -112,7 +112,8 @@ describe('Contact controller, edit', function () {
       })
       it('should include an expanded company', function (done) {
         res.render = function () {
-          expect(res.locals.company).to.deep.equal(contact.company)
+          expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, contact.company.id)
+          expect(res.locals.company).to.deep.equal(company)
           done()
         }
         contactEditController.editDetails(req, res, next)
@@ -136,7 +137,7 @@ describe('Contact controller, edit', function () {
       beforeEach(function () {
         req = {
           session: {
-            token: '1234'
+            token: '321'
           },
           query: {
             company: '1234'
@@ -157,6 +158,7 @@ describe('Contact controller, edit', function () {
       })
       it('should include an expanded company', function (done) {
         res.render = function () {
+          expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
         }
@@ -206,6 +208,7 @@ describe('Contact controller, edit', function () {
       })
       it('should include an expanded company', function (done) {
         res.render = function () {
+          expect(getDitCompanyStub).to.have.been.calledWith(req.session.token, company.id)
           expect(res.locals.company).to.deep.equal(company)
           done()
         }
@@ -294,7 +297,7 @@ describe('Contact controller, edit', function () {
       }
       req = {
         session: {
-          token: '1234'
+          token: '321'
         },
         params: { id: '1234' },
         query: {},
@@ -310,7 +313,7 @@ describe('Contact controller, edit', function () {
     })
     it('should save the form data to the back end', function (done) {
       res.redirect = function () {
-        expect(saveContactFormStub).to.be.calledWith('1234', body)
+        expect(saveContactFormStub).to.be.calledWith(req.session.token, body)
         done()
       }
 

--- a/test/lib/property-helpers.test.js
+++ b/test/lib/property-helpers.test.js
@@ -209,3 +209,24 @@ describe('PropertyHelpers: Check if an object has a property with hasProperty', 
     expect(typeof actual).to.equal('boolean')
   })
 })
+
+describe('PropertyHelpers: Conversion of nested objects', function () {
+  it('Should convert an empty string to null', function () {
+    const source = {
+      foo: 'foo',
+      bar: null
+    }
+    const actual = propertyHelpers.convertNestedObjects(source, ['bar'])
+    expect(actual.bar).be.null
+  })
+  it('Should convert a string to a nested object', function () {
+    const source = {
+      foo: 'foo',
+      bar: 'some-id'
+    }
+    const actual = propertyHelpers.convertNestedObjects(source, ['bar'])
+    expect(actual.bar).to.deep.equal({
+      id: 'some-id'
+    })
+  })
+})

--- a/test/lib/property-helpers.test.js
+++ b/test/lib/property-helpers.test.js
@@ -229,4 +229,16 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
       id: 'some-id'
     })
   })
+  it('Should do nothing if props is not passed in', function () {
+    const source = {
+      foo: 'foo',
+      bar: 'some-id'
+    }
+    const actual = propertyHelpers.convertNestedObjects(source)
+    expect(actual).to.deep.equal(source)
+  })
+  it('Should do nothing if object and props are not passed in', function () {
+    const actual = propertyHelpers.convertNestedObjects()
+    expect(actual).to.deep.equal({})
+  })
 })

--- a/test/services/contact-form.service.test.js
+++ b/test/services/contact-form.service.test.js
@@ -71,11 +71,6 @@ describe('contact form service', function () {
         },
         company: {
           id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
-          created_on: '2014-05-22T21:06:56',
-          modified_on: '2016-02-11T21:48:38',
-          archived: false,
-          archived_on: null,
-          archived_reason: '',
           name: 'OpenStuff'
         },
         advisor: null
@@ -189,8 +184,12 @@ describe('contact form service', function () {
     it('should accept a fully populated contact and convert it to an api format', function () {
       const expected = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
-        company: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
-        title: '0167b456-0ddd-49bd-8184-e3227a0b6396',
+        company: {
+          id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a'
+        },
+        title: {
+          id: '0167b456-0ddd-49bd-8184-e3227a0b6396'
+        },
         first_name: 'Zac',
         last_name: 'Baman',
         job_title: 'Co-founder and CEO',
@@ -206,7 +205,9 @@ describe('contact form service', function () {
         address_town: 'Town view',
         address_county: 'CA',
         address_postcode: '94043',
-        address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
+        address_country: {
+          id: '81756b9a-5d95-e211-a939-e4115bead28a'
+        },
         telephone_alternative: '999',
         email_alternative: 'fred@me.com',
         notes: 'Some notes'

--- a/test/services/contact-formatting.service.test.js
+++ b/test/services/contact-formatting.service.test.js
@@ -2,6 +2,7 @@ const contactFormattingService = require(`${root}/src/services/contact-formattin
 
 describe('Contact formatting service', function () {
   let contact
+  let company
 
   beforeEach(function () {
     contact = {
@@ -37,6 +38,11 @@ describe('Contact formatting service', function () {
       advisor: null,
       address_country: null
     }
+
+    company = {
+      id: '9876',
+      'name': 'My Coorp'
+    }
   })
   describe('contact details', function () {
     it('Should convert a typical contact into its display format', function () {
@@ -50,19 +56,11 @@ describe('Contact formatting service', function () {
         notes: 'some notes'
       }
 
-      const actual = contactFormattingService.getDisplayContact(contact)
+      const actual = contactFormattingService.getDisplayContact(contact, company)
       expect(actual).to.deep.equal(expected)
     })
     it('should use a company trading address if the contact has no address but has a company trading address', function () {
-      contact.address_1 = ''
-      contact.address_2 = ''
-      contact.address_3 = ''
-      contact.address_4 = ''
-      contact.address_town = ''
-      contact.address_county = ''
-      contact.address_postcode = ''
-      contact.address_country = null
-      contact.company = {
+      const companyWithExpectedAddress = {
         id: '1234',
         registered_address_1: '20 The Street',
         registered_address_2: 'rarble',
@@ -80,10 +78,6 @@ describe('Contact formatting service', function () {
         trading_address_postcode: 'TT1 1TT'
       }
 
-      const formatted = contactFormattingService.getDisplayCompanyContact(contact)
-      expect(formatted.address).to.equal('30 The Street, Tarble, Medium Town, Medium County, TT1 1TT, United Kingdom')
-    })
-    it('should use a company trading address if the contact has no address but has a company registered address', function () {
       contact.address_1 = ''
       contact.address_2 = ''
       contact.address_3 = ''
@@ -92,7 +86,13 @@ describe('Contact formatting service', function () {
       contact.address_county = ''
       contact.address_postcode = ''
       contact.address_country = null
-      contact.company = {
+      contact.company = companyWithExpectedAddress
+
+      const formatted = contactFormattingService.getDisplayCompanyContact(contact, companyWithExpectedAddress)
+      expect(formatted.address).to.equal('30 The Street, Tarble, Medium Town, Medium County, TT1 1TT, United Kingdom')
+    })
+    it('should use a company trading address if the contact has no address but has a company registered address', function () {
+      const companyWithExpectedAddress = {
         id: '1234',
         registered_address_1: '20 The Street',
         registered_address_2: 'Rarble',
@@ -110,7 +110,17 @@ describe('Contact formatting service', function () {
         trading_address_postcode: ''
       }
 
-      const formatted = contactFormattingService.getDisplayCompanyContact(contact)
+      contact.address_1 = ''
+      contact.address_2 = ''
+      contact.address_3 = ''
+      contact.address_4 = ''
+      contact.address_town = ''
+      contact.address_county = ''
+      contact.address_postcode = ''
+      contact.address_country = null
+      contact.company = companyWithExpectedAddress
+
+      const formatted = contactFormattingService.getDisplayCompanyContact(contact, companyWithExpectedAddress)
       expect(formatted.address).to.equal('20 The Street, Rarble, Small Town, Small County, RR1 1PP, United Kingdom')
     })
   })
@@ -130,19 +140,11 @@ describe('Contact formatting service', function () {
         telephone_alternative: '07814 000 333'
       }
 
-      const actual = contactFormattingService.getDisplayCompanyContact(contact)
+      const actual = contactFormattingService.getDisplayCompanyContact(contact, company)
       expect(actual).to.deep.equal(expected)
     })
     it('Should use the trading address if no contact address but has a trading address in company', function () {
-      contact.address_1 = ''
-      contact.address_2 = ''
-      contact.address_3 = ''
-      contact.address_4 = ''
-      contact.address_town = ''
-      contact.address_county = ''
-      contact.address_postcode = ''
-      contact.address_country = null
-      contact.company = {
+      const companyWithExpectedAddress = {
         id: '1234',
         registered_address_1: '20 The Street',
         registered_address_2: 'Rarble',
@@ -160,10 +162,6 @@ describe('Contact formatting service', function () {
         trading_address_postcode: 'TT1 1TT'
       }
 
-      const formatted = contactFormattingService.getDisplayCompanyContact(contact)
-      expect(formatted.address).to.equal('30 The Street, Tarble, Medium Town, Medium County, TT1 1TT, United Kingdom')
-    })
-    it('Should use the registered address if no contact address but has a registered address in company', function () {
       contact.address_1 = ''
       contact.address_2 = ''
       contact.address_3 = ''
@@ -172,7 +170,13 @@ describe('Contact formatting service', function () {
       contact.address_county = ''
       contact.address_postcode = ''
       contact.address_country = null
-      contact.company = {
+      contact.company = companyWithExpectedAddress
+
+      const formatted = contactFormattingService.getDisplayCompanyContact(contact, companyWithExpectedAddress)
+      expect(formatted.address).to.equal('30 The Street, Tarble, Medium Town, Medium County, TT1 1TT, United Kingdom')
+    })
+    it('Should use the registered address if no contact address but has a registered address in company', function () {
+      const companyWithExpectedAddress = {
         id: '1234',
         registered_address_1: '20 The Street',
         registered_address_2: 'Rarble',
@@ -189,8 +193,17 @@ describe('Contact formatting service', function () {
         trading_address_county: '',
         trading_address_postcode: ''
       }
+      contact.address_1 = ''
+      contact.address_2 = ''
+      contact.address_3 = ''
+      contact.address_4 = ''
+      contact.address_town = ''
+      contact.address_county = ''
+      contact.address_postcode = ''
+      contact.address_country = null
+      contact.company = companyWithExpectedAddress
 
-      const formatted = contactFormattingService.getDisplayCompanyContact(contact)
+      const formatted = contactFormattingService.getDisplayCompanyContact(contact, companyWithExpectedAddress)
       expect(formatted.address).to.equal('20 The Street, Rarble, Small Town, Small County, RR1 1PP, United Kingdom')
     })
   })
@@ -212,7 +225,7 @@ describe('Contact formatting service', function () {
       archived_on: '14 Feb 2017'
     }
 
-    const actual = contactFormattingService.getDisplayArchivedCompanyContact(contact)
+    const actual = contactFormattingService.getDisplayArchivedCompanyContact(contact, company)
     expect(actual).to.deep.equal(expected)
   })
 })


### PR DESCRIPTION
This refactors the contact services, controllers and related resources to use the new Contact API V3.

**Before**
The API returned complete nested objects eg.
```js
{
  "id": "8d4c80b1-2399-4b45-9d41-192648d3233a",
  "first_name": "Oratio",
  "last_name": "Nelson",
  "company": {
    "alias": "...",
    "business_type": "...",
    "sector": "...",
    "registered_address_country": "...",
    "registered_address_1": "75 Stramford Road",
    "registered_address_town": "London",
    "trading_address_country": "...",
    "trading_address_1": "1 Hello st.",
    "trading_address_town": "Dublin",
    "uk_region": "..."
  }
  ...
}
```
or just flat nested ones eg.

```js
{
  "id": "8d4c80b1-2399-4b45-9d41-192648d3233a",
  "first_name": "Oratio",
  "last_name": "Nelson",
  "company": "s1c8d226-12ed-4d75-a3cd-6ec315a08b74"
  ...
}
```

**After**
The API v3 now return a very light version of nested objects composed of just `id` and `name`. 
```js
{
  "id": "479766dc-855a-4131-be8f-e404063a8ddc",
  "first_name": "Oratio",
  "last_name": "Nelson",
  "company": {
      "id": "d15e46f1-89d7-4edb-9f31-e758ae2f9d54",
      "name": "name6"
  },
  ...
}
```
This is so that responses stay slim but it does mean that sometimes the frontend has to make additional calls.

**So this PR:**
- starts using v3
- changes the display contact functions as before they could access contact.company to get the company address, now they need an extra `company` param
- converts a flat object to a nested one before sending it to the backend to save the object (see `convertNestedObjects`)
- updates now use `PATCH` instead of `PUT`

**Note**
To get the company contacts, the code is still requesting the company object via API and looping over company.contacts. Moving to the new `/v3/contact?company_id=...` endpoint is not part of this PR.