### PR TITLE
Fix issues for IE8 and below

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "^4.14.0",
     "express-session": "^1.14.1",
     "font-awesome": "^4.6.3",
+    "html5shiv": "^3.7.3",
     "istanbul": "^0.4.5",
     "jsdom": "^10.1.0",
     "lodash": "^4.16.4",

--- a/src/views/company/exports-edit.njk
+++ b/src/views/company/exports-edit.njk
@@ -60,5 +60,8 @@
 
     {{ trade.save(backUrl = "/company-exports/view/" + company.id) }}
   </form>
+{% endblock %}
+
+{% block js %}
   <script src="/javascripts/add-another-field.bundle.js"></script>
 {% endblock %}

--- a/src/views/layouts/_base.njk
+++ b/src/views/layouts/_base.njk
@@ -7,6 +7,10 @@
 {% block head %}
   {{ super() }}
 
+  <!--[if lt IE 9]>
+    <script src="{{ asset_path }}javascripts/ie.bundle.js?{{ startTime }}"></script>
+  <![endif]-->
+
   {% include "_includes/google-tag-manager-snippet.njk" %}
 
   {% if user %}

--- a/src/views/layouts/_base.njk
+++ b/src/views/layouts/_base.njk
@@ -24,7 +24,9 @@
 {% block body %}
   {% include "_includes/google-tag-manager-no-script.njk" %}
   {{ super() }}
-  <script src="{{ asset_path }}javascripts/common.js?{{ startTime }}"></script>
-  <script src="{{ asset_path }}javascripts/trade-elements-components-ebe253002f.js"></script>
-  <script src="{{ asset_path }}javascripts/app.bundle.js?{{ startTime }}"></script>
+  <!--[if gt IE 8]><!-->
+    <script src="{{ asset_path }}javascripts/common.js?{{ startTime }}"></script>
+    <script src="{{ asset_path }}javascripts/trade-elements-components-ebe253002f.js"></script>
+    <script src="{{ asset_path }}javascripts/app.bundle.js?{{ startTime }}"></script>
+  <!--<![endif]-->
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ module.exports = {
     search: './src/javascripts/search',
     'service-delivery': './src/javascripts/service-delivery',
     'archive-form': './src/javascripts/archive-form',
-    'add-another-field': './src/javascripts/add-another-field'
+    'add-another-field': './src/javascripts/add-another-field',
+    ie: ['html5shiv']
   },
   output: {
     path: 'build/javascripts',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,10 +56,8 @@ module.exports = {
       sourceMap: false,
       dead_code: true
     }),
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.CommonsChunkPlugin('common.js')
+    new webpack.optimize.DedupePlugin()
   ] : [
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.CommonsChunkPlugin('common.js')
+    new webpack.optimize.DedupePlugin()
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,6 +2743,10 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html5shiv@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/html5shiv/-/html5shiv-3.7.3.tgz#d78a84a367bcb9a710100d57802c387b084631d2"
+
 html@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/html/-/html-1.0.0.tgz#a544fa9ea5492bfb3a2cca8210a10be7b5af1f61"


### PR DESCRIPTION
- Stop serving JS to older IEs
- Fix HTML5 tags for older IEs (shiv)

This change removes Webpack's CommonsChunkPlugin as it was interfering with IE shiv that we pre-bundle with Webpack. At this point the commons JS was very small and wasn't really very useful (we don't serve many vendor files). The way the bundles are build (one per file) also makes it harder to configure commons chunks. It's designed to work with bigger bundles which import other files from within rather than JS file per bundle as it's currently configured.