### PR TITLE
Remember requested url when redirecting unauthorised requests

### DIFF
--- a/src/controllers/login.controller.js
+++ b/src/controllers/login.controller.js
@@ -1,16 +1,15 @@
 /* eslint new-cap: 0 */
 
-const express = require('express')
+const router = require('express').Router()
 const rp = require('request-promise')
-const config = require('../config')
+const { get } = require('lodash')
 
-const router = express.Router()
+const config = require('../config')
 
 function authenticate (username, password) {
   const options = {
     method: 'POST',
-    url: (config.apiRoot + config.api.authUrl),
-
+    url: config.apiRoot + config.api.authUrl,
     headers: {
       'cache-control': 'no-cache',
       'authorization': `Basic ${Buffer.from(config.api.clientId + ':' + config.api.clientSecret).toString('base64')}`,
@@ -28,23 +27,24 @@ function authenticate (username, password) {
 }
 
 function login (req, res) {
-  res.render('login.njk', { action: '/login' })
+  res.render('login.njk')
 }
 
 function loginToApi (req, res, next) {
   if (!req.body.username || !req.body.password) {
     req.flash('error-message', 'Invalid user id or password')
-    res.redirect('/login')
-    return
+    return res.redirect('/login')
   }
 
   authenticate(req.body.username, req.body.password)
     .then((data) => {
       req.session.token = data.access_token
-      res.redirect('/')
+      res.redirect(req.session.returnTo || '/')
     })
     .catch((error) => {
-      if (error.response && error.response.statusCode && error.response.statusCode === 401) {
+      const statusCode = get(error, 'response.statusCode')
+
+      if (statusCode === 401) {
         req.flash('error-message', 'Invalid user id or password')
         res.redirect('/login')
       } else {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,14 +1,12 @@
-const winston = require('winston')
-
 module.exports = function auth (req, res, next) {
-  winston.debug('auth:start')
+  const url = req.url
+  const passThrough = /^\/(support|ping|login)\b/.test(url) || req.session.token
 
-  if (!req.url.startsWith('/ping.xml') && !req.url.startsWith('/support') && req.url !== '/login' && req.url !== '/error' && !req.session.token) {
-    winston.debug('auth:redirect login')
-    res.redirect('/login')
-    return
+  if (passThrough) {
+    return next()
   }
 
-  winston.debug('auth:end')
-  next()
+  req.session.returnTo = req.originalUrl
+
+  return res.redirect('/login')
 }

--- a/src/views/login.njk
+++ b/src/views/login.njk
@@ -28,9 +28,9 @@
 
   {{ trade.errorPanel( messages.formErrors ) }}
 
-  <form action="{{ action }}" method="post">
+  <form action="" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ trade.textbox('username', label="User name", error=errors.username, autofocus=true) }}
+    {{ trade.textbox('username', label="Username", error=errors.username, autofocus=true) }}
     {{ trade.textbox('password', label="Password", error=errors.password, type='password', autocomplete=false) }}
     {{ trade.save(buttonText='Login') }}
   </form>

--- a/test/middleware/auth.test.js
+++ b/test/middleware/auth.test.js
@@ -1,0 +1,62 @@
+const resMock = {}
+
+describe('Auth middleware', () => {
+  beforeEach(() => {
+    this.authMiddleware = require(`${root}/src/middleware/auth`)
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('authenticated/allowed requests', () => {
+    describe('when request contains an allowed url', () => {
+      it('call the next middleware', () => {
+        const reqMock = {
+          url: '/login'
+        }
+
+        this.authMiddleware(reqMock, resMock, this.nextSpy)
+
+        expect(this.nextSpy.calledOnce).to.be.true
+      })
+    })
+  })
+
+  describe('when session token is set', () => {
+    it('call the next middleware', () => {
+      const reqMock = {
+        url: '',
+        session: {
+          token: 'abcd'
+        }
+      }
+
+      this.authMiddleware(reqMock, resMock, this.nextSpy)
+
+      expect(this.nextSpy.calledOnce).to.be.true
+    })
+  })
+
+  describe('unauthenticated requests', () => {
+    it('should set the requested url on the session and redirect', () => {
+      const reqMock = {
+        url: '/protected-url',
+        originalUrl: '/protected-url',
+        session: {}
+      }
+      const resMock = {
+        redirect: this.sandbox.stub()
+      }
+
+      this.authMiddleware(reqMock, resMock, this.nextSpy)
+
+      expect(reqMock.session).to.have.property('returnTo')
+      expect(reqMock.session.returnTo).to.equal('/protected-url')
+      expect(this.nextSpy).not.to.be.called
+      expect(resMock.redirect).to.be.calledWith('/login')
+    })
+  })
+})


### PR DESCRIPTION
When a user requests an authorised url and is not authorised this
will store that url and redirect back there after logging in.

Will default to the homepage if there was no requested url.