### PR TITLE
Add adviser search to investment creation and edit

### DIFF
--- a/src/repos/advisor.repo.js
+++ b/src/repos/advisor.repo.js
@@ -3,6 +3,10 @@ const winston = require('winston')
 const authorisedRequest = require('../lib/authorised-request')
 const config = require('../config')
 
+function getAdvisors (token) {
+  return authorisedRequest(token, `${config.apiRoot}/advisor/`)
+}
+
 function getAdvisor (token, id) {
   return authorisedRequest(token, `${config.apiRoot}/advisor/${id}/`)
 }
@@ -48,4 +52,8 @@ function advisorSearch (token, term) {
   })
 }
 
-module.exports = { getAdvisor, advisorSearch }
+module.exports = {
+  getAdvisors,
+  getAdvisor,
+  advisorSearch
+}

--- a/src/services/investment-formatting.service.js
+++ b/src/services/investment-formatting.service.js
@@ -113,9 +113,6 @@ function transformFromApi (body) {
   formatted['land-date_year'] = date.getFullYear()
   formatted['land-date_month'] = date.getMonth() + 1 // month is zero based index
 
-  formatted['is-relationship-manager'] = formatted.client_relationship_manager
-  formatted['is-referral-source'] = formatted.referral_source_advisor
-
   return Object.assign({}, body, formatted)
 }
 

--- a/src/views/investment/create.njk
+++ b/src/views/investment/create.njk
@@ -57,7 +57,7 @@
       {{ trade.autocomplete('client_relationship_manager',
         label="Client relationship manager",
         value=form.state['client_relationship_manager'],
-        options=form.options.contacts)
+        options=form.options.advisors)
       }}
     </div>
 
@@ -79,7 +79,7 @@
       {{ trade.autocomplete('referral_source_advisor',
         label="Referral source advisor",
         value=form.state['referral_source_advisor'],
-        options=form.options.contacts)
+        options=form.options.advisors)
       }}
     </div>
 


### PR DESCRIPTION
The ability to search and add an adviser was missing. This adds
that ability and the ability to set the value again when
editing.

This code may change when the journey for creating and editing
an investment project gets split into multiple sections.

![advisor-search](https://cloud.githubusercontent.com/assets/3327997/26689827/f43208b2-46ee-11e7-8550-216038f8c903.gif)
