### PR TITLE
Enforce comma dangle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,16 @@
   "extends": "standard",
   "parser": "babel-eslint",
   "rules": {
-    "comma-dangle": "off",
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "never",
+        "exports": "never",
+        "functions": "ignore"
+      }
+    ],
     "object-curly-spacing": ["error", "always"]
   }
 }

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -24,7 +24,7 @@ const filters = {
     }
 
     return string
-  }
+  },
 }
 
 module.exports = filters

--- a/config/nunjucks/index.js
+++ b/config/nunjucks/index.js
@@ -39,12 +39,12 @@ function ComponentExtension (env) {
 module.exports = (app, config) => {
   const env = nunjucks.configure([
     `${config.root}/src/views`,
-    `${config.root}/node_modules/@uktrade/trade_elements/dist/nunjucks`
+    `${config.root}/node_modules/@uktrade/trade_elements/dist/nunjucks`,
   ], {
     autoescape: true,
     express: app,
     watch: config.isDev,
-    noCache: config.isDev
+    noCache: config.isDev,
   })
   const tradeElementsFilters = require(`@uktrade/trade_elements/dist/nunjucks/filters`)
   const dataHubFilters = require('./filters')

--- a/src/config.js
+++ b/src/config.js
@@ -13,23 +13,23 @@ module.exports = {
   api: {
     authUrl: '/token/',
     clientId: process.env.API_CLIENT_ID,
-    clientSecret: process.env.API_CLIENT_SECRET
+    clientSecret: process.env.API_CLIENT_SECRET,
   },
   postcodeLookup: {
     apiKey: process.env.POSTCODE_KEY,
-    baseUrl: 'https://api.getAddress.io/v2/uk/{postcode}?api-key={api-key}'
+    baseUrl: 'https://api.getAddress.io/v2/uk/{postcode}?api-key={api-key}',
   },
   redis: {
     url: process.env.REDIS_URL || process.env.REDISTOGO_URL,
     port: process.env.REDIS_PORT || 6379,
     host: process.env.REDIS_HOST || 'redis',
-    metadataTtl: (process.env.METADATA_TTL || (15 * 60))
+    metadataTtl: (process.env.METADATA_TTL || (15 * 60)),
   },
   googleTagManagerKey: process.env.GOOGLE_TAG_MANAGER_KEY,
   session: {
     secret: process.env.SESSION_SECRET || 'howdoesyourgardengrow',
     // 2 hour timeout
-    ttl: process.env.SESSION_TTL || (2 * 60 * 60 * 1000)
+    ttl: process.env.SESSION_TTL || (2 * 60 * 60 * 1000),
   },
   logLevel: process.env.LOG_LEVEL || defaultLogLevel,
   zenUrl: `https://${process.env.ZEN_DOMAIN}.zendesk.com/api/v2/tickets.json`,
@@ -39,5 +39,5 @@ module.exports = {
   zenImpact: process.env.ZEN_IMPACT,
   zenService: process.env.ZEN_SERVICE,
   longDateFormat: 'D MMMM YYYY',
-  mediumDateFormat: 'D MMM YYYY'
+  mediumDateFormat: 'D MMM YYYY',
 }

--- a/src/controllers/api.controller.js
+++ b/src/controllers/api.controller.js
@@ -26,5 +26,5 @@ router.get('/api/postcodelookup/:postcode', postcodelookup)
 
 module.exports = {
   postcodelookup,
-  router
+  router,
 }

--- a/src/controllers/company-add.controller.js
+++ b/src/controllers/company-add.controller.js
@@ -16,7 +16,7 @@ function getAddStepOne (req, res, next) {
     foreignOtherCompanyOptions,
     company: req.body,
     companyTypeOptions,
-    companyDetailsLabels
+    companyDetailsLabels,
   })
 }
 
@@ -47,19 +47,19 @@ function postAddStepOne (req, res, next) {
     case 'ltdchild':
       params = {
         business_type: req.body.business_type,
-        country: 'uk'
+        country: 'uk',
       }
       break
     case 'ukother':
       params = {
         business_type: req.body.business_type_uk_other,
-        country: 'uk'
+        country: 'uk',
       }
       break
     case 'foreign':
       params = {
         business_type: req.body.business_type_for_other,
-        country: 'non-uk'
+        country: 'non-uk',
       }
       break
   }

--- a/src/controllers/company-export.controller.js
+++ b/src/controllers/company-export.controller.js
@@ -8,7 +8,7 @@ const router = express.Router()
 
 const exportDetailsLabels = {
   exportToCountries: 'Currently exporting to',
-  futureInterestCountries: 'Future countries of interest'
+  futureInterestCountries: 'Future countries of interest',
 }
 
 /**
@@ -60,10 +60,10 @@ function view (req, res, next) {
       const data = {
         exportDetails: {
           exportToCountries: company.export_to_countries.map(country => country.name).join(', '),
-          futureInterestCountries: company.future_interest_countries.map(country => country.name).join()
+          futureInterestCountries: company.future_interest_countries.map(country => country.name).join(),
         },
         exportDetailsLabels,
-        exportDetailsDisplayOrder: ['exportToCountries', 'futureInterestCountries']
+        exportDetailsDisplayOrder: ['exportToCountries', 'futureInterestCountries'],
       }
 
       res.render('company/exports-view', data)
@@ -84,7 +84,7 @@ function edit (req, res, next) {
 
       const data = {
         exportDetailsLabels,
-        countryOptions: metadataRepository.countryOptions
+        countryOptions: metadataRepository.countryOptions,
       }
 
       if (containsFormData(req)) {
@@ -125,7 +125,7 @@ function post (req, res, next) {
       flattenIdFields(company)
       const postData = Object.assign({}, company, {
         export_to_countries: req.body.export_to_countries,
-        future_interest_countries: req.body.future_interest_countries
+        future_interest_countries: req.body.future_interest_countries,
       })
 
       yield saveCompany(req.session.token, postData)

--- a/src/controllers/company-foreign.controller.js
+++ b/src/controllers/company-foreign.controller.js
@@ -24,7 +24,7 @@ function getDetails (req, res, next) {
 
       res.locals.accountManagementDisplay = {
         oneListTier: (company.classification && company.classification !== null && company.classification.name) ? company.classification.name : 'None',
-        oneListAccountManager: 'None'
+        oneListAccountManager: 'None',
       }
       res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
 
@@ -53,7 +53,7 @@ function addDetails (req, res, next) {
     res.locals.formData = req.body
   } else {
     res.locals.formData = {
-      business_type: metadataRepository.getIdForName(metadataRepository.businessTypeOptions, req.query.business_type).id
+      business_type: metadataRepository.getIdForName(metadataRepository.businessTypeOptions, req.query.business_type).id,
     }
   }
   res.locals.businessTypeName = req.query.business_type

--- a/src/controllers/company-ltd.controller.js
+++ b/src/controllers/company-ltd.controller.js
@@ -31,7 +31,7 @@ function getDetails (req, res, next) {
 
       res.locals.accountManagementDisplay = {
         oneListTier: (company.classification && company.classification !== null && company.classification.name) ? company.classification.name : 'None',
-        oneListAccountManager: 'None'
+        oneListAccountManager: 'None',
       }
       res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
 

--- a/src/controllers/company-ukother.controller.js
+++ b/src/controllers/company-ukother.controller.js
@@ -24,7 +24,7 @@ function getDetails (req, res, next) {
 
       res.locals.accountManagementDisplay = {
         oneListTier: (company.classification && company.classification !== null && company.classification.name) ? company.classification.name : 'None',
-        oneListAccountManager: 'None'
+        oneListAccountManager: 'None',
       }
       res.locals.accountManagementDisplayLabels = accountManagementDisplayLabels
       res.render('company/details-ukother')
@@ -53,7 +53,7 @@ function addDetails (req, res, next) {
     res.locals.formData = req.body
   } else {
     res.locals.formData = {
-      business_type: metadataRepository.getIdForName(metadataRepository.businessTypeOptions, req.query.business_type).id
+      business_type: metadataRepository.getIdForName(metadataRepository.businessTypeOptions, req.query.business_type).id,
     }
   }
   res.locals.businessTypeName = req.query.business_type

--- a/src/controllers/contact.controller.js
+++ b/src/controllers/contact.controller.js
@@ -11,7 +11,7 @@ const router = express.Router()
 const reasonForArchiveOptions = [
   'Contact has left the company',
   'Contact does not want to be contacted',
-  'Contact changed role/responsibility'
+  'Contact changed role/responsibility',
 ]
 
 function getCommon (req, res, next) {

--- a/src/controllers/index.controller.js
+++ b/src/controllers/index.controller.js
@@ -8,7 +8,7 @@ module.exports = (req, res) => {
       res.render('index', {
         totalDays: days,
         interactions: data.interactions,
-        contacts: data.contacts
+        contacts: data.contacts,
       })
     })
 }

--- a/src/controllers/interaction-edit.controller.js
+++ b/src/controllers/interaction-edit.controller.js
@@ -55,7 +55,7 @@ function editDetails (req, res, next) {
       res.locals.contacts = companyContacts.map((contact) => {
         return {
           id: contact.id,
-          name: `${contact.first_name} ${contact.last_name}`
+          name: `${contact.first_name} ${contact.last_name}`,
         }
       })
 

--- a/src/controllers/interaction.controller.js
+++ b/src/controllers/interaction.controller.js
@@ -55,7 +55,7 @@ function getAddStep1 (req, res) {
   res.render('interaction/add-step-1.njk', {
     query: req.query,
     interactionTypeColA,
-    interactionTypeColB
+    interactionTypeColB,
   })
 }
 
@@ -63,7 +63,7 @@ function postAddStep1 (req, res) {
   // error if no selection
   if (!req.body.interaction_type) {
     res.locals.errors = {
-      interaction_type: ['You must select an interaction type']
+      interaction_type: ['You must select an interaction type'],
     }
     return getAddStep1(req, res)
   }

--- a/src/controllers/investment-create.controller.js
+++ b/src/controllers/investment-create.controller.js
@@ -5,7 +5,7 @@ const {
   getCompanyInvestmentProjects,
   getInvestmentProjectSummary,
   createInvestmentProject,
-  updateInvestmentProject
+  updateInvestmentProject,
 } = require('../repos/investment.repo')
 const { transformToApi, transformFromApi } = require('../services/investment-formatting.service')
 const { getAdvisors } = require('../repos/advisor.repo')
@@ -16,7 +16,7 @@ function getHandler (req, res, next) {
   const promises = [
     getInflatedDitCompany(req.session.token, equityCompanyId),
     getCompanyInvestmentProjects(req.session.token, equityCompanyId),
-    getAdvisors(req.session.token)
+    getAdvisors(req.session.token),
   ]
 
   if (!equityCompanyId) {
@@ -29,19 +29,19 @@ function getHandler (req, res, next) {
       const contacts = equityCompany.contacts.map((contact) => {
         return {
           id: contact.id,
-          name: `${contact.first_name} ${contact.last_name}`
+          name: `${contact.first_name} ${contact.last_name}`,
         }
       })
       const investmentTypes = metadataRepo.investmentTypeOptions.map((type) => {
         return {
           value: type.id,
-          label: type.name
+          label: type.name,
         }
       })
       const advisors = advisorResponse.results.map((advisor) => {
         return {
           id: advisor.id,
-          name: `${advisor.first_name} ${advisor.last_name}`
+          name: `${advisor.first_name} ${advisor.last_name}`,
         }
       })
 
@@ -55,13 +55,13 @@ function getHandler (req, res, next) {
         referralSourceMarketing: metadataRepo.referralSourceMarketingOptions,
         referralSourceWebsite: metadataRepo.referralSourceWebsiteOptions,
         primarySectors: metadataRepo.sectorOptions,
-        businessActivities: metadataRepo.businessActivityOptions
+        businessActivities: metadataRepo.businessActivityOptions,
       }
 
       res.render('investment/create', {
         equityCompany,
         equityCompanyInvestments,
-        form
+        form,
       })
     })
     .catch(next)
@@ -136,5 +136,5 @@ module.exports = {
   router,
   getHandler,
   postHandler,
-  editMiddleware
+  editMiddleware,
 }

--- a/src/controllers/investment-details.controller.js
+++ b/src/controllers/investment-details.controller.js
@@ -6,7 +6,7 @@ const { buildCompanyUrl } = require('../services/company.service')
 const {
   getInvestmentProjectSummary,
   getInvestmentValue,
-  getInvestmentRequirements
+  getInvestmentRequirements,
 } = require('../repos/investment.repo')
 
 const localNavItems = [
@@ -16,7 +16,7 @@ const localNavItems = [
   { label: 'Interactions', slug: 'interactions' },
   { label: 'Documents', slug: 'documents' },
   { label: 'Evaluation', slug: 'evaluation' },
-  { label: 'Audit history', slug: 'audit' }
+  { label: 'Audit history', slug: 'audit' },
 ]
 
 function formatProjectStatusData (data) {
@@ -24,7 +24,7 @@ function formatProjectStatusData (data) {
     id: data.id,
     name: data.name,
     projectCode: data.project_code,
-    phaseName: data.phase.name
+    phaseName: data.phase.name,
   }
 }
 
@@ -32,7 +32,7 @@ function formatProjectData (data) {
   return {
     'Client': {
       name: data.investor_company.name,
-      url: buildCompanyUrl(data.investor_company)
+      url: buildCompanyUrl(data.investor_company),
     },
     'Type of investment': data.investment_type.name,
     'Primary sector': data.sector,
@@ -42,7 +42,7 @@ function formatProjectData (data) {
     'Non-disclosure agreement': data.nda_signed ? 'Signed' : 'Not signed',
     'Shareable with UK partners': null,
     'Anonymous description': null,
-    'Estimated land date': data.estimated_land_date ? moment(data.estimated_land_date).format('MMMM YYYY') : null
+    'Estimated land date': data.estimated_land_date ? moment(data.estimated_land_date).format('MMMM YYYY') : null,
   }
 }
 
@@ -57,7 +57,7 @@ function formatValueData (data) {
     'R&D budget': data.r_and_d_budget,
     'Non-FDI R&D project': data.non_fdi_r_and_d_budget,
     'New-to-world tech': data.new_tech_to_uk,
-    'Export revenue': data.export_revenue
+    'Export revenue': data.export_revenue,
   }
 }
 
@@ -68,7 +68,7 @@ function formatRequirementsData (data) {
     'Competitor countries': data.competitor_countries,
     'Possible UK locations': data.uk_region_locations,
     'Investment location': null,
-    'UK recipient company': data.uk_company
+    'UK recipient company': data.uk_company,
   }
 }
 
@@ -85,7 +85,7 @@ function getDetails (req, res, next) {
         project: formatProjectData(projectData),
         value: formatValueData(valueData),
         requirements: formatRequirementsData(requirementsData),
-        localNavItems
+        localNavItems,
       })
     } catch (error) {
       next(error)

--- a/src/controllers/investment-start.controller.js
+++ b/src/controllers/investment-start.controller.js
@@ -25,7 +25,7 @@ function getHandler (req, res, next) {
     promises.push(search({
       token: req.session.token,
       page: req.query.page,
-      term: searchTerm
+      term: searchTerm,
     }))
   } else {
     promises.push(Promise.resolve())
@@ -50,7 +50,7 @@ function getHandler (req, res, next) {
         searchTerm,
         searchResult,
         pagination,
-        showSearch
+        showSearch,
       })
     })
     .catch(next)
@@ -70,8 +70,8 @@ function postHandler (req, res, next) {
         res.render('investment/start', {
           clientCompany,
           errors: {
-            isEquitySource: 'Please select whether this company will be the source of foreign equity'
-          }
+            isEquitySource: 'Please select whether this company will be the source of foreign equity',
+          },
         })
       })
       .catch(next)

--- a/src/controllers/login.controller.js
+++ b/src/controllers/login.controller.js
@@ -13,14 +13,14 @@ function authenticate (username, password) {
     headers: {
       'cache-control': 'no-cache',
       'authorization': `Basic ${Buffer.from(config.api.clientId + ':' + config.api.clientSecret).toString('base64')}`,
-      'content-type': 'multipart/form-data; boundary=---011000010111000001101001'
+      'content-type': 'multipart/form-data; boundary=---011000010111000001101001',
     },
     formData: {
       username: username,
       password: password,
-      grant_type: 'password'
+      grant_type: 'password',
     },
-    json: true
+    json: true,
   }
 
   return rp(options)

--- a/src/controllers/search.controller.js
+++ b/src/controllers/search.controller.js
@@ -12,7 +12,7 @@ const router = express.Router()
 function buildSearchEntityResultsData (searchEntityResults) {
   const navItemText = {
     company: 'Companies',
-    contact: 'Contacts'
+    contact: 'Contacts',
   }
 
   return searchEntityResults.map((searchEntityResult) => {
@@ -20,7 +20,7 @@ function buildSearchEntityResultsData (searchEntityResults) {
       {},
       searchEntityResult,
       {
-        text: navItemText[searchEntityResult.entity]
+        text: navItemText[searchEntityResult.entity],
       }
     )
   })
@@ -39,10 +39,10 @@ const searchActionValidationSchema = Celebrate({
     searchType: Joi.string().valid(
       [
         'company',
-        'contact'
+        'contact',
       ]
-    )
-  }
+    ),
+  },
 })
 
 function searchAction (req, res, next) {
@@ -53,7 +53,7 @@ function searchAction (req, res, next) {
     token: req.session.token,
     searchTerm,
     searchType,
-    page: req.query.page
+    page: req.query.page,
   })
     .then((results) => {
       const pagination = getPagination(req, results)
@@ -64,7 +64,7 @@ function searchAction (req, res, next) {
         searchType,
         searchEntityResultsData,
         results,
-        pagination
+        pagination,
       })
     })
     .catch(next)
@@ -89,5 +89,5 @@ module.exports = {
   router,
   indexAction,
   searchAction,
-  viewCompanyResult
+  viewCompanyResult,
 }

--- a/src/controllers/service-delivery.controller.js
+++ b/src/controllers/service-delivery.controller.js
@@ -49,7 +49,7 @@ function getServiceDeliveryEdit (req, res, next) {
       res.locals.contacts = res.locals.serviceDelivery.company.contacts.map((contact) => {
         return {
           id: contact.id,
-          name: `${contact.first_name} ${contact.last_name}`
+          name: `${contact.first_name} ${contact.last_name}`,
         }
       })
 

--- a/src/controllers/support.controller.js
+++ b/src/controllers/support.controller.js
@@ -15,8 +15,8 @@ function postToZen (ticket) {
     {
       auth: {
         username: `${config.zenEmail}/token`,
-        password: config.zenToken
-      }
+        password: config.zenToken,
+      },
     }
   )
 }
@@ -54,17 +54,17 @@ function postBug (req, res) {
   }
   const ticket = {
     requester: {
-      name: 'Data Hub user'
+      name: 'Data Hub user',
     },
     subject: req.body.title,
     comment: {
-      body: (req.body.description && req.body.description.length > 0) ? req.body.description : 'N/A'
+      body: (req.body.description && req.body.description.length > 0) ? req.body.description : 'N/A',
     },
     custom_fields: [
       { id: config.zenBrowser, value: req.body.browser },
-      { id: config.zenService, value: 'datahub_export' }
+      { id: config.zenService, value: 'datahub_export' },
     ],
-    tags: [req.body.type]
+    tags: [req.body.type],
   }
   if (req.body.email && req.body.email.length > 0) {
     ticket.requester.email = req.body.email

--- a/src/javascripts/expandable-card.js
+++ b/src/javascripts/expandable-card.js
@@ -4,7 +4,7 @@ const {
   toggleVisible,
   toggleClass,
   addClass,
-  createElementFromMarkup
+  createElementFromMarkup,
 } = require('../lib/element-stuff')
 
 /**

--- a/src/javascripts/facets.js
+++ b/src/javascripts/facets.js
@@ -36,7 +36,7 @@ class Facets {
   selectOptionHandler = (event) => {
     const input = event.target || event.srcElement
     const queryParams = {
-      term: decodeURIComponent(term)
+      term: decodeURIComponent(term),
     }
 
     if (input.checked) {
@@ -48,7 +48,7 @@ class Facets {
 
   clearFacetSelection = () => {
     const queryParams = {
-      term: decodeURIComponent(term)
+      term: decodeURIComponent(term),
     }
 
     this.checkboxInputs.forEach((input) => {

--- a/src/javascripts/modules/conditional-subfields.js
+++ b/src/javascripts/modules/conditional-subfields.js
@@ -144,7 +144,7 @@ const ConditionalSubfields = {
         field.dispatchEvent(event)
       })
     }
-  }
+  },
 }
 
 module.exports = ConditionalSubfields

--- a/src/labels/company-labels.js
+++ b/src/labels/company-labels.js
@@ -25,7 +25,7 @@ const companyDetailsLabels = {
   registered_address_country: 'Registered address country',
   business_type_for_other: 'Type of organisation',
   business_type_uk_other: 'Type of organisation',
-  headquarter_type: 'Headquarters'
+  headquarter_type: 'Headquarters',
 }
 const chDetailsLabels = {
   name: 'Registered name',
@@ -34,23 +34,23 @@ const chDetailsLabels = {
   business_type: 'Company type',
   company_status: 'Company status',
   sic_code: 'Nature of business (SIC)',
-  incorporation_date: 'Incorporated on'
+  incorporation_date: 'Incorporated on',
 }
 const companyTypeOptions = {
   ltd: 'UK private or public limited company',
   ltdchild: 'Child of a UK private or public limited company',
   ukother: 'Other type of UK organisation',
-  foreign: 'Foreign organisation'
+  foreign: 'Foreign organisation',
 }
 
 const hqLabels = {
   'ehq': 'European headquarters (EHQ)',
   'ghq': 'Global headquarters (GHQ)',
-  'ukhq': 'UK headquarters (UK HQ)'
+  'ukhq': 'UK headquarters (UK HQ)',
 }
 const accountManagementDisplayLabels = {
   oneListTier: 'One List tier',
-  oneListAccountManager: 'One List account manager'
+  oneListAccountManager: 'One List account manager',
 }
 
 module.exports = { companyDetailsLabels, chDetailsLabels, companyTypeOptions, hqLabels, accountManagementDisplayLabels }

--- a/src/labels/contact-labels.js
+++ b/src/labels/contact-labels.js
@@ -10,7 +10,7 @@ const contactDetailsLabels = {
   notes: 'Notes',
   address_same_as_company: 'Address same as company',
   first_name: 'First name',
-  last_name: 'Last name'
+  last_name: 'Last name',
 }
 
 module.exports = { contactDetailsLabels }

--- a/src/labels/interaction-labels.js
+++ b/src/labels/interaction-labels.js
@@ -7,5 +7,5 @@ module.exports = {
   dit_advisor: 'DIT adviser',
   service: 'Service offer',
   dit_team: 'Service provider',
-  interaction_type: 'Interaction type'
+  interaction_type: 'Interaction type',
 }

--- a/src/labels/investment-labels.js
+++ b/src/labels/investment-labels.js
@@ -2,14 +2,14 @@ const investmentProjectsOpenLabels = {
   name: 'Open projects',
   value: 'Value',
   state: 'Stage',
-  land_date: 'Land date'
+  land_date: 'Land date',
 }
 
 const investmentProjectsClosedLabels = {
   name: 'Closed projects',
   value: 'Value',
   state: 'Status',
-  state_date: 'Status date'
+  state_date: 'Status date',
 }
 
 const investmentDetailLabels = {
@@ -18,14 +18,14 @@ const investmentDetailLabels = {
   investment_account_manager: 'Investment account manager',
   account_manager: 'Account manager',
   client_relationship_manager: 'Client relationship manager',
-  ownership: 'Ownership'
+  ownership: 'Ownership',
 }
 
 const investmentBriefDetails = {
   company_name: 'Company',
   country_address: 'Country of Address',
   investment_in_uk: 'Investment in the UK',
-  account_management_tier: 'Account tier'
+  account_management_tier: 'Account tier',
 }
 
 const investmentFormLabels = {
@@ -33,7 +33,7 @@ const investmentFormLabels = {
   investment_tier: 'Investment account manager tier',
   investment_account_manager: 'Investment account manager',
   client_relationship_manager: 'Client relationship manager',
-  ownership: 'Ownership'
+  ownership: 'Ownership',
 }
 
 const detailsDisplay = {
@@ -45,13 +45,13 @@ const detailsDisplay = {
   project_description: 'Project description',
   nda_signed: 'Non-disclosure agreement',
   project_shareable: 'Shareable with UK partners',
-  estimated_land_date: 'Estimated land date'
+  estimated_land_date: 'Estimated land date',
 }
 
 const referLabels = {
   referral_activity: 'Activity',
   referral_event: 'Event',
-  referral_advisor: 'Advisor'
+  referral_advisor: 'Advisor',
 }
 
 module.exports = {
@@ -61,5 +61,5 @@ module.exports = {
   investmentFormLabels,
   investmentBriefDetails,
   detailsDisplay,
-  referLabels
+  referLabels,
 }

--- a/src/labels/service-delivery.js
+++ b/src/labels/service-delivery.js
@@ -11,5 +11,5 @@ module.exports = {
   uk_region: 'UK region',
   sector: 'Sector',
   country_of_interest: 'Country of interest',
-  'event': 'Event'
+  'event': 'Event',
 }

--- a/src/lib/authorised-request.js
+++ b/src/lib/authorised-request.js
@@ -29,7 +29,7 @@ function jsonReviver (key, value) {
 // script tags
 module.exports = (token, opts) => {
   const requestOptions = {
-    json: true
+    json: true,
   }
 
   if (isString(opts)) {

--- a/src/lib/controller-utils.js
+++ b/src/lib/controller-utils.js
@@ -88,7 +88,7 @@ function convertAutosuggestCollection (form, targetFieldName) {
     if (fieldName.toLocaleLowerCase().substr(0, targetFieldName.length) === lowerTargetFieldName) {
       form[targetFieldName].push({
         id: form[fieldName],
-        name: form[`${fieldName}-display`]
+        name: form[`${fieldName}-display`],
       })
       delete form[`${fieldName}-display`]
       delete form[fieldName]
@@ -143,5 +143,5 @@ module.exports = {
   flattenIdFields,
   isBlank,
   toQueryString,
-  containsFormData
+  containsFormData,
 }

--- a/src/lib/date.js
+++ b/src/lib/date.js
@@ -16,5 +16,5 @@ function formatMediumDate (date) {
 }
 
 module.exports = {
-  formatLongDate, formatMediumDate
+  formatLongDate, formatMediumDate,
 }

--- a/src/lib/element-stuff.js
+++ b/src/lib/element-stuff.js
@@ -132,5 +132,5 @@ module.exports = {
   show,
   createElementFromMarkup,
   removeElement,
-  toggleVisible
+  toggleVisible,
 }

--- a/src/lib/pagination.js
+++ b/src/lib/pagination.js
@@ -45,7 +45,7 @@ function getPagination (req, result) {
   if (currentPage > 1) {
     pagination.push({
       label: PREVIOUSLABEL,
-      link: getPageLink(currentPage - 1, req)
+      link: getPageLink(currentPage - 1, req),
     })
   }
 
@@ -53,14 +53,14 @@ function getPagination (req, result) {
     pagination.push({
       label: `${pos}`,
       link: getPageLink(pos, req),
-      currentPage: (pos === currentPage)
+      currentPage: (pos === currentPage),
     })
   }
 
   if (pageIndexes.nextPage) {
     pagination.push({
       label: NEXTLABEL,
-      link: getPageLink(pageIndexes.nextPage, req)
+      link: getPageLink(pageIndexes.nextPage, req),
     })
   }
 

--- a/src/lib/property-helpers.js
+++ b/src/lib/property-helpers.js
@@ -95,7 +95,7 @@ function convertNestedObjects (object = {}, props = []) {
 
     if (value) {
       convertedObject[prop] = {
-        id: value
+        id: value,
       }
     }
   }
@@ -131,5 +131,5 @@ module.exports = {
   getPropertyName,
   hasObjectProperty,
   hasProperty,
-  nullEmptyFields
+  nullEmptyFields,
 }

--- a/src/lib/sanitizers.js
+++ b/src/lib/sanitizers.js
@@ -31,5 +31,5 @@ function yesNoToBoolean (value) {
 }
 
 module.exports = {
-  trimArray, joinArray, yesNoToBoolean, toArray
+  trimArray, joinArray, yesNoToBoolean, toArray,
 }

--- a/src/lib/transform-sectors.js
+++ b/src/lib/transform-sectors.js
@@ -33,7 +33,7 @@ function getAllSubSectors (sectorName, allSectors) {
     .filter(sector => getPrimarySectorName(sector.name) === sectorName)
     .map(sector => ({
       id: sector.id,
-      name: getSubsectorName(sector.name)
+      name: getSubsectorName(sector.name),
     }))
 
   if (allSubSectors === null || allSubSectors.length === 1) return null
@@ -56,5 +56,5 @@ module.exports = {
   getAllSubSectors,
   getAllPrimarySectors,
   getSectorForName,
-  getSectorForId
+  getSectorForId,
 }

--- a/src/lib/url-helpers.js
+++ b/src/lib/url-helpers.js
@@ -46,5 +46,5 @@ function buildQueryString (params) {
 module.exports = {
   getQueryParam,
   getBackLink,
-  buildQueryString
+  buildQueryString,
 }

--- a/src/middleware/errors.js
+++ b/src/middleware/errors.js
@@ -28,11 +28,11 @@ function catchAll (error, req, res, next) {
     .render('errors/index', {
       statusCode,
       statusMessage,
-      devErrorDetail: config.isDev && error
+      devErrorDetail: config.isDev && error,
     })
 }
 
 module.exports = {
   notFound,
-  catchAll
+  catchAll,
 }

--- a/src/middleware/flash.js
+++ b/src/middleware/flash.js
@@ -7,7 +7,7 @@ module.exports = (req, res, next) => {
   res.locals.messages = {
     success: req.flash('success-message'),
     error: req.flash('error-message'),
-    info: req.flash('info')
+    info: req.flash('info'),
   }
 
   if (formErrors && formErrors.length) {

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -11,7 +11,7 @@ module.exports = (req, res, next) => {
         req.session.user = {
           id: userInfo.id, // DIT Advisor id
           name: userInfo.name,
-          team: userInfo.dit_team
+          team: userInfo.dit_team,
         }
 
         res.locals.user = req.session.user

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -6,13 +6,13 @@ const investmentTierOptions = [
   'C - IST managed',
   'C - IST managed - Partner lead',
   'D - LEP managed',
-  'D - Post managed'
+  'D - Post managed',
 ]
 const managedOptions = [
   'C - IST managed',
   'C - IST managed - Partner lead',
   'D - LEP managed',
-  'D - Post managed'
+  'D - Post managed',
 ]
 
 const ukOtherCompanyOptions = [
@@ -21,7 +21,7 @@ const ukOtherCompanyOptions = [
   'Intermediary',
   'Limited partnership',
   'Partnership',
-  'Sole trader'
+  'Sole trader',
 ]
 const foreignOtherCompanyOptions = [
   'Charity',
@@ -30,12 +30,12 @@ const foreignOtherCompanyOptions = [
   'Intermediary',
   'Limited partnership',
   'Partnership',
-  'Sole trader'
+  'Sole trader',
 ]
 
 module.exports = {
   investmentTierOptions,
   managedOptions,
   ukOtherCompanyOptions,
-  foreignOtherCompanyOptions
+  foreignOtherCompanyOptions,
 }

--- a/src/repos/advisor.repo.js
+++ b/src/repos/advisor.repo.js
@@ -55,5 +55,5 @@ function advisorSearch (token, term) {
 module.exports = {
   getAdvisors,
   getAdvisor,
-  advisorSearch
+  advisorSearch,
 }

--- a/src/repos/company.repo.js
+++ b/src/repos/company.repo.js
@@ -39,12 +39,12 @@ function saveCompany (token, company) {
         if (typeof error.error === 'string') {
           reject({
             statusCode: error.response.statusCode,
-            errors: { detail: error.response.statusMessage }
+            errors: { detail: error.response.statusMessage },
           })
         } else {
           reject({
             statusCode: error.response.statusCode,
-            errors: error.error
+            errors: error.error,
           })
         }
       }
@@ -56,7 +56,7 @@ function archiveCompany (token, companyId, reason) {
   const options = {
     body: { reason },
     url: `${config.apiRoot}/company/${companyId}/archive/`,
-    method: 'POST'
+    method: 'POST',
   }
   return authorisedRequest(token, options)
 }
@@ -70,5 +70,5 @@ module.exports = {
   getDitCompany,
   getCHCompany,
   archiveCompany,
-  unarchiveCompany
+  unarchiveCompany,
 }

--- a/src/repos/contact.repo.js
+++ b/src/repos/contact.repo.js
@@ -10,7 +10,7 @@ function getContact (token, contactId) {
 
 function saveContact (token, contact) {
   let options = {
-    body: contact
+    body: contact,
   }
 
   if (contact.id && contact.id.length > 0) {
@@ -29,7 +29,7 @@ function archiveContact (token, contactId, reason) {
   const options = {
     body: { reason },
     url: `${config.apiRoot}/v3/contact/${contactId}/archive`,
-    method: 'POST'
+    method: 'POST',
   }
   return authorisedRequest(token, options)
 }

--- a/src/repos/interaction.repo.js
+++ b/src/repos/interaction.repo.js
@@ -8,7 +8,7 @@ function getInteraction (token, interactionId) {
 
 function saveInteraction (token, interaction) {
   const options = {
-    body: interaction
+    body: interaction,
   }
 
   if (interaction.id && interaction.id.length > 0) {
@@ -47,5 +47,5 @@ function getInteractionsForContact (token, contactId) {
 module.exports = {
   saveInteraction,
   getInteraction,
-  getInteractionsForContact
+  getInteractionsForContact,
 }

--- a/src/repos/investment.repo.js
+++ b/src/repos/investment.repo.js
@@ -21,7 +21,7 @@ function createInvestmentProject (token, body) {
   return authorisedRequest(token, {
     url: `${config.apiRoot}/v3/investment/project`,
     method: 'POST',
-    body
+    body,
   })
 }
 
@@ -29,7 +29,7 @@ function updateInvestmentProject (token, investmentId, body) {
   return authorisedRequest(token, {
     url: `${config.apiRoot}/v3/investment/${investmentId}/project`,
     method: 'PATCH',
-    body
+    body,
   })
 }
 
@@ -39,5 +39,5 @@ module.exports = {
   getInvestmentValue,
   getInvestmentRequirements,
   createInvestmentProject,
-  updateInvestmentProject
+  updateInvestmentProject,
 }

--- a/src/repos/metadata.repo.js
+++ b/src/repos/metadata.repo.js
@@ -146,7 +146,7 @@ module.exports.fetchAll = (cb) => {
 
 module.exports.REASONS_FOR_ARCHIVE = [
   'Company is dissolved',
-  'Other'
+  'Other',
 ]
 
 module.exports.getServiceOffers = function (token) {

--- a/src/repos/service-delivery.repo.js
+++ b/src/repos/service-delivery.repo.js
@@ -4,7 +4,7 @@ const config = require('../config')
 
 function saveServiceDelivery (token, serviceDelivery) {
   const options = {
-    body: serviceDelivery
+    body: serviceDelivery,
   }
   // v2 endpoint only supports POST
   options.method = 'POST'
@@ -55,5 +55,5 @@ module.exports = {
   getServiceDelivery,
   saveServiceDelivery,
   getServiceDeliveriesForCompany,
-  getServiceDeliveriesForContact
+  getServiceDeliveriesForContact,
 }

--- a/src/server.js
+++ b/src/server.js
@@ -76,7 +76,7 @@ const redisStore = new RedisStore({
   client,
   // config ttl defined in milliseconds
   ttl: config.session.ttl / 1000,
-  secret: config.session.secret
+  secret: config.session.secret,
 })
 
 app.use(session({
@@ -84,13 +84,13 @@ app.use(session({
   proxy: !isDev,
   cookie: {
     secure: !isDev,
-    maxAge: config.session.ttl
+    maxAge: config.session.ttl,
   },
   rolling: true,
   key: 'datahub.sid',
   secret: config.session.secret,
   resave: true,
-  saveUninitialized: true
+  saveUninitialized: true,
 }))
 
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))

--- a/src/services/company-form.service.js
+++ b/src/services/company-form.service.js
@@ -38,7 +38,7 @@ function getLtdCompanyAsFormData (company) {
     website: company.website,
     description: company.description,
     employee_range: getPropertyId(company, 'employee_range'),
-    turnover_range: getPropertyId(company, 'turnover_range')
+    turnover_range: getPropertyId(company, 'turnover_range'),
   }
 
   result = nullEmptyFields(result)
@@ -77,7 +77,7 @@ function getUkOtherCompanyAsFormData (company) {
     website: company.website,
     description: company.description,
     employee_range: getPropertyId(company, 'employee_range'),
-    turnover_range: getPropertyId(company, 'turnover_range')
+    turnover_range: getPropertyId(company, 'turnover_range'),
   }
 
   result = nullEmptyFields(result)
@@ -115,7 +115,7 @@ function getForeignCompanyAsFormData (company) {
     website: company.website,
     description: company.description,
     employee_range: getPropertyId(company, 'employee_range'),
-    turnover_range: getPropertyId(company, 'turnover_range')
+    turnover_range: getPropertyId(company, 'turnover_range'),
   }
 
   result = nullEmptyFields(result)
@@ -141,7 +141,7 @@ function getDefaultLtdFormForCH (companies_house_data) {
     registered_address_town: companies_house_data.registered_address_town,
     registered_address_county: companies_house_data.registered_address_county,
     registered_address_postcode: companies_house_data.registered_address_postcode,
-    registered_address_country: getPropertyId(companies_house_data, 'registered_address_country')
+    registered_address_country: getPropertyId(companies_house_data, 'registered_address_country'),
   }
 
   result = nullEmptyFields(result)

--- a/src/services/company-formatting.service.js
+++ b/src/services/company-formatting.service.js
@@ -18,7 +18,7 @@ function getDisplayCH (companyHouseData) {
     business_type: companyHouseData.company_category,
     company_status: companyHouseData.company_status,
     registered_address: getFormattedAddress(companyHouseData, 'registered'),
-    incorporation_date: formatLongDate(companyHouseData.incorporation_date)
+    incorporation_date: formatLongDate(companyHouseData.incorporation_date),
   }
 
   displayCH.sic_code = []
@@ -41,7 +41,7 @@ function getDisplayCompany (company) {
     turnover_range: (company.turnover_range && company.turnover_range.name) ? company.turnover_range.name : null,
     account_manager: (company.account_manager && company.account_manager.name) ? company.account_manager.name : null,
     headquarter_type: (company.headquarter_type && company.headquarter_type.name && company.headquarter_type.name.length > 0) ? hqLabels[company.headquarter_type.name] : 'Not a headquarters',
-    alias: company.alias || null
+    alias: company.alias || null,
   }
 
   if (company.alias && company.alias.length > 0) displayCompany.alias = company.alias
@@ -73,7 +73,7 @@ function parseRelatedData (companies) {
     const url = buildCompanyUrl(company)
     return {
       name: `<a href="${url}">${company.alias || company.name}</a>`,
-      address
+      address,
     }
   })
 }
@@ -84,5 +84,5 @@ module.exports = {
   getDisplayCH,
   getDisplayCompany,
   parseRelatedData,
-  companyTableKeys
+  companyTableKeys,
 }

--- a/src/services/company.service.js
+++ b/src/services/company.service.js
@@ -46,7 +46,7 @@ function getInflatedDitCompany (token, id) {
             interaction_type: { id: null, name: 'Service delivery' },
             dit_advisor: advisorHash[serviceDelivery.relationships.dit_advisor.data.id],
             service: serviceOffers.find((option) => option.id === serviceDelivery.relationships.service.data.id),
-            dit_team: metadataRepository.teams.find((option) => option.id === serviceDelivery.relationships.dit_team.data.id)
+            dit_team: metadataRepository.teams.find((option) => option.id === serviceDelivery.relationships.dit_team.data.id),
           })
         })
 
@@ -57,7 +57,7 @@ function getInflatedDitCompany (token, id) {
             interaction_type: interactionDataService.getInteractionType(interaction.interaction_type),
             dit_advisor: advisorHash[interaction.dit_advisor],
             service: serviceOffers.find((option) => option.id === interaction.service),
-            dit_team: metadataRepository.teams.find((option) => option.id === interaction.dit_team)
+            dit_team: metadataRepository.teams.find((option) => option.id === interaction.dit_team),
           })
         })
 
@@ -83,7 +83,7 @@ function getCompanyForSource (token, id, source) {
             company_number: id,
             companies_house_data,
             contacts: [],
-            interactions: []
+            interactions: [],
           })
           return
         }

--- a/src/services/contact-data.service.js
+++ b/src/services/contact-data.service.js
@@ -62,7 +62,7 @@ function getContactInteractionsAndServiceDeliveries (token, contactId) {
               interaction_type: { id: null, name: 'Service delivery' },
               dit_advisor: advisorHash[serviceDelivery.relationships.dit_advisor.data.id],
               service: serviceOffers.find((option) => option.id === serviceDelivery.relationships.service.data.id),
-              dit_team: metadataRepository.teams.find((option) => option.id === serviceDelivery.relationships.dit_team.data.id)
+              dit_team: metadataRepository.teams.find((option) => option.id === serviceDelivery.relationships.dit_team.data.id),
             })
         })
 

--- a/src/services/contact-form.service.js
+++ b/src/services/contact-form.service.js
@@ -3,7 +3,7 @@ const {
   convertNestedObjects,
   convertYesNoToBoolean,
   getPropertyId,
-  nullEmptyFields
+  nullEmptyFields,
 } = require('../lib/property-helpers')
 const contactRepository = require('../repos/contact.repo')
 
@@ -40,7 +40,7 @@ function getContactAsFormData (contact) {
     address_country: getPropertyId(contact, 'address_country'),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,
-    notes: contact.notes
+    notes: contact.notes,
   }
 
   result = nullEmptyFields(result)

--- a/src/services/contact-formatting.service.js
+++ b/src/services/contact-formatting.service.js
@@ -27,7 +27,7 @@ function getDisplayContact (contact, company) {
     address: getContactAddress(contact, company),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,
-    notes: newlineToBr(contact.notes)
+    notes: newlineToBr(contact.notes),
   }
 }
 
@@ -50,7 +50,7 @@ function getDisplayCompanyContact (contact, company) {
     address: getContactAddress(contact, company),
     telephone_alternative: contact.telephone_alternative,
     email_alternative: contact.email_alternative,
-    notes: newlineToBr(contact.notes)
+    notes: newlineToBr(contact.notes),
   }
 }
 
@@ -67,7 +67,7 @@ function getDisplayArchivedCompanyContact (contact) {
     job_title: contact.job_title,
     reason: contact.archived_reason,
     archived_on: formatMediumDate(contact.archived_on),
-    archived_by: `${contact.archived_by.first_name} ${contact.archived_by.last_name}`
+    archived_by: `${contact.archived_by.first_name} ${contact.archived_by.last_name}`,
   }
 }
 

--- a/src/services/dashboard.service.js
+++ b/src/services/dashboard.service.js
@@ -12,8 +12,8 @@ function mapContacts (contacts) {
         company: {
           url: buildCompanyUrl(contact.company),
           name: contact.company.name,
-          id: contact.company.id
-        }
+          id: contact.company.id,
+        },
       }
     })
   }
@@ -31,8 +31,8 @@ function mapInteractions (interactions) {
         subject: interaction.subject,
         company: {
           name: company ? company.name : null,
-          url: company ? buildCompanyUrl(company) : null
-        }
+          url: company ? buildCompanyUrl(company) : null,
+        },
       }
     })
   }
@@ -47,5 +47,5 @@ module.exports = {
       data.interactions = mapInteractions(data.interactions)
       return data
     })
-  }
+  },
 }

--- a/src/services/interaction-data.service.js
+++ b/src/services/interaction-data.service.js
@@ -52,12 +52,12 @@ function createBlankInteractionForContact (token, dit_advisor, interaction_type,
           date: new Date(),
           service: {
             id: null,
-            name: null
+            name: null,
           },
           dit_team: {
             id: null,
-            name: null
-          }
+            name: null,
+          },
         })
       } catch (error) {
         reject(error)
@@ -84,12 +84,12 @@ function createBlankInteractionForCompany (token, dit_advisor, interaction_type,
           date: new Date(),
           service: {
             id: null,
-            name: null
+            name: null,
           },
           dit_team: {
             id: null,
-            name: null
-          }
+            name: null,
+          },
         })
       } catch (error) {
         reject(error)
@@ -102,5 +102,5 @@ module.exports = {
   getInteractionType,
   getHydratedInteraction,
   createBlankInteractionForCompany,
-  createBlankInteractionForContact
+  createBlankInteractionForContact,
 }

--- a/src/services/interaction-form.service.js
+++ b/src/services/interaction-form.service.js
@@ -21,7 +21,7 @@ function getInteractionAsFormData (interaction) {
     date: interaction.date || null,
     dit_advisor: getPropertyId(interaction, 'dit_advisor'),
     service: getPropertyId(interaction, 'service'),
-    dit_team: getPropertyId(interaction, 'dit_team')
+    dit_team: getPropertyId(interaction, 'dit_team'),
   }
 
   result = nullEmptyFields(result)
@@ -59,5 +59,5 @@ function saveInteractionForm (token, interactionForm) {
 
 module.exports = {
   saveInteractionForm,
-  getInteractionAsFormData
+  getInteractionAsFormData,
 }

--- a/src/services/interaction-formatting.service.js
+++ b/src/services/interaction-formatting.service.js
@@ -21,7 +21,7 @@ function getDisplayInteraction (interaction) {
     dit_advisor: getPropertyName(interaction, 'dit_advisor'),
     service: getPropertyName(interaction, 'service'),
     dit_team: getPropertyName(interaction, 'dit_team'),
-    contact: getContactLink(interaction)
+    contact: getContactLink(interaction),
   }
 
   return result
@@ -47,7 +47,7 @@ function getDisplayCompanyInteraction (interaction) {
     contact: getContactLink(interaction),
     notes: newlineToBr(interaction.notes),
     service: getPropertyName(interaction, 'service'),
-    dit_team: getPropertyName(interaction, 'dit_team')
+    dit_team: getPropertyName(interaction, 'dit_team'),
   }
   return result
 }
@@ -71,7 +71,7 @@ function getDisplayContactInteraction (interaction) {
     advisor: getPropertyName(interaction, 'dit_advisor'),
     notes: newlineToBr(interaction.notes),
     service: getPropertyName(interaction, 'service'),
-    dit_team: getPropertyName(interaction, 'dit_team')
+    dit_team: getPropertyName(interaction, 'dit_team'),
   }
 
   return result

--- a/src/services/investment-formatting.service.js
+++ b/src/services/investment-formatting.service.js
@@ -37,7 +37,7 @@ function getOpenInvestmentProjects (investmentProjects) {
         name: `<a href="/investmentprojects/${project.id}/">${project.name}</a>`,
         value: project.value,
         state: project.state,
-        land_date: formatLongDate(project.land_date)
+        land_date: formatLongDate(project.land_date),
       }
     })
 }
@@ -51,7 +51,7 @@ function getClosedInvestmentProjects (investmentProjects) {
         name: `<a href="/investmentprojects/${project.id}/">${project.name}</a>`,
         value: project.value,
         state: project.state,
-        state_date: formatLongDate(project.state_date)
+        state_date: formatLongDate(project.state_date),
       }
     })
 }
@@ -132,5 +132,5 @@ module.exports = {
   getOpenInvestmentProjects,
   getClosedInvestmentProjects,
   transformToApi,
-  transformFromApi
+  transformFromApi,
 }

--- a/src/services/item-collection.service.js
+++ b/src/services/item-collection.service.js
@@ -31,5 +31,5 @@ function getItemsAddedInLastYear (items) {
 
 module.exports = {
   getTimeSinceLastAddedItem,
-  getItemsAddedInLastYear
+  getItemsAddedInLastYear,
 }

--- a/src/services/postcode.service.js
+++ b/src/services/postcode.service.js
@@ -50,5 +50,5 @@ function parsePostcodeResult (data, postcode) {
   })
 }
 module.exports = {
-  lookupAddress
+  lookupAddress,
 }

--- a/src/services/remote-company.service.js
+++ b/src/services/remote-company.service.js
@@ -6,5 +6,5 @@ function getCompanyForSource (token = null, id, source) {
 }
 
 module.exports = {
-  getCompanyForSource
+  getCompanyForSource,
 }

--- a/src/services/remote-contact.service.js
+++ b/src/services/remote-contact.service.js
@@ -6,5 +6,5 @@ function getInflatedContact (token = null, id) {
 }
 
 module.exports = {
-  getInflatedContact
+  getInflatedContact,
 }

--- a/src/services/search.service.js
+++ b/src/services/search.service.js
@@ -9,12 +9,12 @@ function search ({ token, searchTerm, searchType, limit = 10, page = 1 }) {
     term: searchTerm,
     entity: searchType,
     limit,
-    offset: (page * limit) - limit
+    offset: (page * limit) - limit,
   }
 
   const options = {
     url: `${config.apiRoot}/v3/search${buildQueryString(params)}`,
-    method: 'GET'
+    method: 'GET',
   }
 
   return authorisedRequest(token, options)
@@ -35,9 +35,9 @@ function suggestCompany (token, term, types) {
       term,
       doc_type: types,
       limit: 10,
-      offset: 0
+      offset: 0,
     },
-    method: 'POST'
+    method: 'POST',
   }
 
   return authorisedRequest(token, options)
@@ -47,7 +47,7 @@ function suggestCompany (token, term, types) {
         .map((hit) => ({
           name: hit._source.name,
           id: hit._id,
-          _type: hit._type
+          _type: hit._type,
         }))
     })
     .catch((error) => {

--- a/src/services/service-delivery-formatting.service.js
+++ b/src/services/service-delivery-formatting.service.js
@@ -20,7 +20,7 @@ function getDisplayServiceDelivery (serviceDelivery) {
     uk_region: getPropertyName(serviceDelivery, 'uk_region'),
     sector: getPropertyName(serviceDelivery, 'sector'),
     contact: getContactLink(serviceDelivery),
-    country_of_interest: getPropertyName(serviceDelivery, 'country_of_interest')
+    country_of_interest: getPropertyName(serviceDelivery, 'country_of_interest'),
   }
 
   return result

--- a/src/services/service-delivery.service.js
+++ b/src/services/service-delivery.service.js
@@ -65,7 +65,7 @@ function convertServiceDeliveryFormToApiFormat (serviceDeliveryForm) {
       attributes: {
         subject: serviceDeliveryForm.subject,
         notes: serviceDeliveryForm.notes,
-        date: serviceDeliveryForm.date
+        date: serviceDeliveryForm.date,
       },
       relationships: {
         company: { data: { type: 'Company', id: serviceDeliveryForm.company } },
@@ -76,9 +76,9 @@ function convertServiceDeliveryFormToApiFormat (serviceDeliveryForm) {
         dit_advisor: { data: { type: 'Advisor', id: serviceDeliveryForm.dit_advisor } },
         uk_region: { data: { type: 'UKRegion', id: serviceDeliveryForm.uk_region } },
         sector: { data: { type: 'Sector', id: serviceDeliveryForm.sector } },
-        country_of_interest: { data: { type: 'Country', id: serviceDeliveryForm.country_of_interest } }
-      }
-    }
+        country_of_interest: { data: { type: 'Country', id: serviceDeliveryForm.country_of_interest } },
+      },
+    },
   }
 
   if (serviceDeliveryForm.id && serviceDeliveryForm.id.length > 0) {
@@ -105,8 +105,8 @@ function createBlankServiceDeliveryForContact (token, dit_advisor, contactId) {
           date: new Date(),
           dit_team: {
             id: null,
-            name: null
-          }
+            name: null,
+          },
         })
       } catch (error) {
         reject(error)
@@ -123,7 +123,7 @@ function createBlankServiceDeliveryForCompany (token, dit_advisor, companyId) {
         resolve({
           company,
           dit_advisor,
-          date: new Date()
+          date: new Date(),
         })
       } catch (error) {
         reject(error)
@@ -149,7 +149,7 @@ function convertFormBodyBackToServiceDelivery (token, flatServiceDelivery) {
           status: { id: flatServiceDelivery.status },
           uk_region: { id: flatServiceDelivery.uk_region },
           sector: { id: flatServiceDelivery.sector },
-          country_of_interest: { id: flatServiceDelivery.country_of_interest }
+          country_of_interest: { id: flatServiceDelivery.country_of_interest },
         }
 
         if (flatServiceDelivery.contact) {
@@ -181,5 +181,5 @@ module.exports = {
   convertServiceDeliveryFormToApiFormat,
   createBlankServiceDeliveryForContact,
   createBlankServiceDeliveryForCompany,
-  convertFormBodyBackToServiceDelivery
+  convertFormBodyBackToServiceDelivery,
 }

--- a/test/component-helper.js
+++ b/test/component-helper.js
@@ -7,7 +7,7 @@ const { JSDOM } = require('jsdom')
 const nunjucksConfig = require('../config/nunjucks')
 
 const nunjucks = nunjucksConfig(null, {
-  root: path.normalize(`${__dirname}/..`)
+  root: path.normalize(`${__dirname}/..`),
 })
 
 const COMPONENTS_PATH = '_components/'
@@ -16,11 +16,11 @@ const COMPONENT_EXT = 'njk'
 const normaliseHtml = (string) => {
   const beautiful = htmlBeautifier(string, {
     indent_size: 2,
-    max_preserve_newlines: 0
+    max_preserve_newlines: 0,
   })
 
   return html.prettyPrint(beautiful, {
-    indent_size: 2
+    indent_size: 2,
   })
 }
 
@@ -45,5 +45,5 @@ const expectComponent = (name, input, expected) => {
 
 module.exports = {
   expectComponent,
-  renderComponentToDom
+  renderComponentToDom,
 }

--- a/test/components/form-multilpe-select.test.js
+++ b/test/components/form-multilpe-select.test.js
@@ -15,9 +15,9 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
-            }
-          ]
+              value: 'marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group inline">
@@ -45,9 +45,9 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
-            }
-          ]
+              value: 'marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group error">
@@ -74,9 +74,9 @@ describe('Form multiple choice component', () => {
           error: true,
           children: [
             {
-              label: 'My marbells'
-            }
-          ]
+              label: 'My marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group error">
@@ -103,9 +103,9 @@ describe('Form multiple choice component', () => {
           optional: true,
           children: [
             {
-              label: 'My marbells'
-            }
-          ]
+              label: 'My marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group">
@@ -132,9 +132,9 @@ describe('Form multiple choice component', () => {
           hint: 'Choose an option',
           children: [
             {
-              label: 'My marbells'
-            }
-          ]
+              label: 'My marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group">
@@ -166,9 +166,9 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
-            }
-          ]
+              value: 'marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group">
@@ -196,13 +196,13 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
+              value: 'marbells',
             },
             {
               label: 'For love',
-              value: 'love'
-            }
-          ]
+              value: 'love',
+            },
+          ],
         },
         `
         <fieldset class="form-group">
@@ -238,9 +238,9 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
-            }
-          ]
+              value: 'marbells',
+            },
+          ],
         },
         `
         <fieldset class="form-group">
@@ -268,13 +268,13 @@ describe('Form multiple choice component', () => {
           children: [
             {
               label: 'My marbells',
-              value: 'marbells'
+              value: 'marbells',
             },
             {
               label: 'For love',
-              value: 'love'
-            }
-          ]
+              value: 'love',
+            },
+          ],
         },
         `
         <fieldset class="form-group">

--- a/test/components/key-value-table.test.js
+++ b/test/components/key-value-table.test.js
@@ -13,8 +13,8 @@ describe('Key/value table component', () => {
       {
         items: {
           'First label': '#1 label content',
-          'Second label': '#2 label content'
-        }
+          'Second label': '#2 label content',
+        },
       }
     )
 
@@ -34,9 +34,9 @@ describe('Key/value table component', () => {
         items: {
           'First label': {
             name: '#1 label content',
-            url: '/label-1'
-          }
-        }
+            url: '/label-1',
+          },
+        },
       }
     )
 
@@ -49,9 +49,9 @@ describe('Key/value table component', () => {
       'key-value-table',
       {
         items: {
-          'First label': '#1 label content'
+          'First label': '#1 label content',
         },
-        variant: 'custom-variant'
+        variant: 'custom-variant',
       }
     )
 

--- a/test/components/pagination.test.js
+++ b/test/components/pagination.test.js
@@ -5,7 +5,7 @@ describe('Pagination component', () => {
     const component = renderComponentToDom(
       'pagination',
       {
-        pages: []
+        pages: [],
       }
     )
 
@@ -18,14 +18,14 @@ describe('Pagination component', () => {
         {
           label: 'example-label',
           link: 'example-link',
-          currentPage: true
+          currentPage: true,
         },
         {
           label: 'example-label-1',
           link: 'example-link-1',
-          currentPage: false
-        }
-      ]
+          currentPage: false,
+        },
+      ],
     }
     const component = renderComponentToDom(
       'pagination',

--- a/test/components/project-status.test.js
+++ b/test/components/project-status.test.js
@@ -7,7 +7,7 @@ describe('Project status component', () => {
       {
         id: 'project id',
         name: 'Project name',
-        phaseName: 'Initial'
+        phaseName: 'Initial',
       }
     )
 
@@ -21,7 +21,7 @@ describe('Project status component', () => {
         id: 'project id',
         name: 'Project name',
         projectCode: 'PROJECT-CODE',
-        phaseName: 'Initial'
+        phaseName: 'Initial',
       }
     )
 
@@ -37,7 +37,7 @@ describe('Project status component', () => {
       {
         id: 'project id',
         name: 'Project name',
-        projectCode: 'PROJECT-CODE'
+        projectCode: 'PROJECT-CODE',
       }
     )
 

--- a/test/components/results-summary.test.js
+++ b/test/components/results-summary.test.js
@@ -3,7 +3,7 @@ const { renderComponentToDom } = require('../component-helper')
 describe('Results Summary component', () => {
   it('should render with default values', () => {
     const mockData = {
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',
@@ -22,7 +22,7 @@ describe('Results Summary component', () => {
   it('should render with singular default values', () => {
     const mockData = {
       total: 1,
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',
@@ -42,7 +42,7 @@ describe('Results Summary component', () => {
     const mockData = {
       total: 1,
       resultType: 'company',
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',
@@ -63,7 +63,7 @@ describe('Results Summary component', () => {
       total: 11,
       resultType: 'company',
       pluralisedResultType: 'companies',
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',
@@ -84,7 +84,7 @@ describe('Results Summary component', () => {
       total: 22,
       resultType: 'company',
       pluralisedResultType: 'companies',
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',
@@ -104,7 +104,7 @@ describe('Results Summary component', () => {
     const mockData = {
       total: 22,
       resultType: 'contact',
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'results-summary',

--- a/test/components/search-bar.test.js
+++ b/test/components/search-bar.test.js
@@ -5,7 +5,7 @@ describe('Search Bar component', () => {
     const mockData = {
       action: '/example/action',
       label: 'Search for company name or contact',
-      searchTerm: 'mock search term'
+      searchTerm: 'mock search term',
     }
     const component = renderComponentToDom(
       'search-bar',
@@ -32,7 +32,7 @@ describe('Search Bar component', () => {
       label: 'Search for company name or contact',
       searchTerm: 'mock search term',
       placeholder: 'mock place holder text',
-      submitText: 'mock submit text'
+      submitText: 'mock submit text',
     }
     const component = renderComponentToDom(
       'search-bar',

--- a/test/components/search-nav.test.js
+++ b/test/components/search-nav.test.js
@@ -5,7 +5,7 @@ describe('Search Nav component', () => {
     const component = renderComponentToDom(
       'search-nav',
       {
-        searchEntityResults: []
+        searchEntityResults: [],
       }
     )
 
@@ -18,16 +18,16 @@ describe('Search Nav component', () => {
         {
           count: 1,
           text: 'Companies',
-          entity: 'company'
+          entity: 'company',
         },
         {
           count: 2,
           text: 'Contacts',
-          entity: 'contact'
-        }
+          entity: 'contact',
+        },
       ],
       searchType: 'company',
-      searchTerm: 'example search term'
+      searchTerm: 'example search term',
     }
     const component = renderComponentToDom(
       'search-nav',

--- a/test/controllers/company-add.controller.test.js
+++ b/test/controllers/company-add.controller.test.js
@@ -15,9 +15,9 @@ describe('Company add controller', function () {
         _source: {
           id: '1234',
           company_number: '123123',
-          name: 'freds'
-        }
-      }
+          name: 'freds',
+        },
+      },
     ])
 
     getCompanyForSourceStub = sinon.stub().resolves({ id: '9999', company_number: '8888' })
@@ -25,14 +25,14 @@ describe('Company add controller', function () {
 
     companyAddController = proxyquire('~/src/controllers/company-add.controller', {
       '../services/search.service': {
-        searchLimited: searchLimitedStub
+        searchLimited: searchLimitedStub,
       },
       '../services/company.service': {
-        getCompanyForSource: getCompanyForSourceStub
+        getCompanyForSource: getCompanyForSourceStub,
       },
       '../services/company-formatting.service': {
-        getDisplayCH: getDisplayCHStub
-      }
+        getDisplayCH: getDisplayCHStub,
+      },
     })
   })
 
@@ -49,7 +49,7 @@ describe('Company add controller', function () {
             'Intermediary',
             'Limited partnership',
             'Partnership',
-            'Sole trader'
+            'Sole trader',
           ])
           expect(allOptions.foreignOtherCompanyOptions).to.deep.equal([
             'Charity',
@@ -58,10 +58,10 @@ describe('Company add controller', function () {
             'Intermediary',
             'Limited partnership',
             'Partnership',
-            'Sole trader'
+            'Sole trader',
           ])
           done()
-        }
+        },
       }
 
       companyAddController.getAddStepOne(req, res, next)
@@ -76,11 +76,11 @@ describe('Company add controller', function () {
             ltd: 'UK private or public limited company',
             ltdchild: 'Child of a UK private or public limited company',
             ukother: 'Other type of UK organisation',
-            foreign: 'Foreign organisation'
+            foreign: 'Foreign organisation',
           })
           expect(allOptions.companyDetailsLabels.business_type).to.equal('Business type')
           done()
-        }
+        },
       }
 
       companyAddController.getAddStepOne(req, res, next)
@@ -96,11 +96,11 @@ describe('Company add controller', function () {
             ltd: 'UK private or public limited company',
             ltdchild: 'Child of a UK private or public limited company',
             ukother: 'Other type of UK organisation',
-            foreign: 'Foreign organisation'
+            foreign: 'Foreign organisation',
           })
           expect(allOptions.company).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyAddController.getAddStepOne(req, res, next)
@@ -111,16 +111,16 @@ describe('Company add controller', function () {
       it('should forward the user to step 2 when adding a uk ltd.', function (done) {
         const req = {
           body: {
-            business_type: 'ltd'
+            business_type: 'ltd',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/company/add-step-2/?business_type=ltd&country=uk')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
@@ -128,16 +128,16 @@ describe('Company add controller', function () {
         const req = {
           body: {
             business_type: 'ukother',
-            business_type_uk_other: 'Charity'
+            business_type_uk_other: 'Charity',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/company/add/ukother?business_type=Charity&country=uk')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
@@ -145,16 +145,16 @@ describe('Company add controller', function () {
         const req = {
           body: {
             business_type: 'foreign',
-            business_type_for_other: 'Charity'
+            business_type_for_other: 'Charity',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
           redirect: function (url) {
             expect(url).to.equal('/company/add/foreign?business_type=Charity&country=non-uk')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
@@ -163,7 +163,7 @@ describe('Company add controller', function () {
       it('should show an error when no option selected', function (done) {
         const req = {
           body: {},
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
@@ -171,16 +171,16 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors).to.have.property('business_type')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should show an error if other uk selected but no option selected from the list', function (done) {
         const req = {
           body: {
-            business_type: 'ukother'
+            business_type: 'ukother',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
@@ -188,16 +188,16 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors).to.have.property('business_type_uk_other')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
       it('should show an error if foreign selected but no option selected from the list', function (done) {
         const req = {
           body: {
-            business_type: 'foreign'
+            business_type: 'foreign',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
@@ -205,7 +205,7 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.errors).to.have.property('business_type_for_other')
             done()
-          }
+          },
         }
         companyAddController.postAddStepOne(req, res, next)
       })
@@ -217,16 +217,16 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk'
+            country: 'uk',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
           render: function (template, options) {
             expect(template).to.equal('company/add-step-2.njk')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
@@ -234,9 +234,9 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk'
+            country: 'uk',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
@@ -246,10 +246,10 @@ describe('Company add controller', function () {
               ltd: 'UK private or public limited company',
               ltdchild: 'Child of a UK private or public limited company',
               ukother: 'Other type of UK organisation',
-              foreign: 'Foreign organisation'
+              foreign: 'Foreign organisation',
             })
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
@@ -257,9 +257,9 @@ describe('Company add controller', function () {
         const req = {
           query: {
             business_type: 'ltd',
-            country: 'uk'
+            country: 'uk',
           },
-          session: {}
+          session: {},
         }
         const res = {
           locals: {},
@@ -268,7 +268,7 @@ describe('Company add controller', function () {
             expect(allOptions.business_type).to.equal('ltd')
             expect(allOptions.country).to.equal('uk')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
@@ -277,33 +277,33 @@ describe('Company add controller', function () {
       it('should search for the company name entered', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
-            term: 'test'
-          }
+            term: 'test',
+          },
         }
         const res = {
           locals: {},
           render: function (template, options) {
             expect(searchLimitedStub).to.be.calledWith('1234', 'test')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include parsed search results in page', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
-            term: 'test'
-          }
+            term: 'test',
+          },
         }
         const res = {
           locals: {},
@@ -314,21 +314,21 @@ describe('Company add controller', function () {
             expect(hit.url).to.include('selected=1234')
             expect(hit.name).to.equal('freds')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include business information after search in page when selected is blank', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
-            selected: ''
-          }
+            selected: '',
+          },
         }
         const res = {
           locals: {},
@@ -338,21 +338,21 @@ describe('Company add controller', function () {
             expect(allOptions.country).to.equal('uk')
             expect(allOptions.term).to.equal('test')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include business information after search in page when selected has a value', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
-            selected: '9999'
-          }
+            selected: '9999',
+          },
         }
         const res = {
           locals: {},
@@ -362,7 +362,7 @@ describe('Company add controller', function () {
             expect(allOptions.country).to.equal('uk')
             expect(allOptions.term).to.equal('test')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
@@ -371,59 +371,59 @@ describe('Company add controller', function () {
       it('should fetch the ch company', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '9999',
-            type: 'company_company'
-          }
+            type: 'company_company',
+          },
         }
         const res = {
           locals: {},
           render: function (template, options) {
             expect(getCompanyForSourceStub).to.be.calledWith('1234', '9999', 'company_company')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should parse the CH details for display', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '1234',
-            type: 'company_company'
-          }
+            type: 'company_company',
+          },
         }
         const res = {
           locals: {},
           render: function (template, options) {
             expect(getDisplayCHStub).to.have.been.called
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include labels and display order for the table', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '1234',
-            type: 'company_company'
-          }
+            type: 'company_company',
+          },
         }
         const res = {
           locals: {},
@@ -436,26 +436,26 @@ describe('Company add controller', function () {
               business_type: 'Company type',
               company_status: 'Company status',
               sic_code: 'Nature of business (SIC)',
-              incorporation_date: 'Incorporated on'
+              incorporation_date: 'Incorporated on',
             })
             expect(allOptions.chDetailsDisplayOrder).to.deep.equal(['business_type', 'company_status', 'incorporation_date', 'sic_code'])
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should include a link to close the selected section', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '1234',
-            type: 'company_company'
-          }
+            type: 'company_company',
+          },
         }
         const res = {
           locals: {},
@@ -463,22 +463,22 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.closeLink).to.not.include('selected')
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should provide a link to edit a DIT company record if one exists', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '1234',
-            type: 'company_company'
-          }
+            type: 'company_company',
+          },
         }
 
         const res = {
@@ -487,25 +487,25 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.addLink).to.deep.equal({
               label: 'Go to company record',
-              url: `/company/edit/ltd/9999`
+              url: `/company/edit/ltd/9999`,
             })
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })
       it('should provide a link to add a new DIT company record for a companies house entry', function (done) {
         const req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
           query: {
             business_type: 'ltd',
             country: 'uk',
             term: 'test',
             selected: '1234',
-            type: 'company_companieshousecompany'
-          }
+            type: 'company_companieshousecompany',
+          },
         }
 
         const res = {
@@ -514,10 +514,10 @@ describe('Company add controller', function () {
             const allOptions = mergeLocals(res, options)
             expect(allOptions.addLink).to.deep.equal({
               label: 'Choose company',
-              url: `/company/add/ltd/8888`
+              url: `/company/add/ltd/8888`,
             })
             done()
-          }
+          },
         }
         companyAddController.getAddStepTwo(req, res, next)
       })

--- a/test/controllers/company-archive.controller.test.js
+++ b/test/controllers/company-archive.controller.test.js
@@ -19,7 +19,7 @@ describe('Company controller, archive', function () {
     registered_address_4: null,
     registered_address_town: 'PRESTON',
     registered_address_county: '',
-    registered_address_postcode: 'PR1 0LS'
+    registered_address_postcode: 'PR1 0LS',
   }
   let getDitCompanyStub
   let companyArchiveController
@@ -31,13 +31,13 @@ describe('Company controller, archive', function () {
     companyRepositoryUnArchiveCompanyStub = sinon.stub().resolves(null)
     companyArchiveController = proxyquire('~/src/controllers/company-archive.controller', {
       '../services/company.service': {
-        buildCompanyUrl: buildCompanyUrlStub
+        buildCompanyUrl: buildCompanyUrlStub,
       },
       '../repos/company.repo': {
         getDitCompany: getDitCompanyStub,
         archiveCompany: companyRepositoryArchiveCompanyStub,
-        unarchiveCompany: companyRepositoryUnArchiveCompanyStub
-      }
+        unarchiveCompany: companyRepositoryUnArchiveCompanyStub,
+      },
     })
     flashStub = sinon.stub()
   })
@@ -46,16 +46,16 @@ describe('Company controller, archive', function () {
       session: { token },
       body: { archived_reason: 'test', archived_reason_other: '' },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(companyRepositoryArchiveCompanyStub).to.be.calledWith(token, company.id, req.body.archived_reason)
         done()
-      }
+      },
     }
 
     companyArchiveController.archiveCompany(req, res, next)
@@ -65,16 +65,16 @@ describe('Company controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: 'otherreason' },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(companyRepositoryArchiveCompanyStub).to.be.calledWith(token, company.id, req.body.archived_reason_other)
         done()
-      }
+      },
     }
 
     companyArchiveController.archiveCompany(req, res, next)
@@ -84,9 +84,9 @@ describe('Company controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: 'otherreason' },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
@@ -95,7 +95,7 @@ describe('Company controller, archive', function () {
         expect(buildCompanyUrlStub).to.be.calledWith(company)
         expect(url).to.equal('/testurl')
         done()
-      }
+      },
     }
 
     companyArchiveController.archiveCompany(req, res, next)
@@ -105,16 +105,16 @@ describe('Company controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: 'otherreason' },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('success-message', 'Updated company record')
         done()
-      }
+      },
     }
 
     companyArchiveController.archiveCompany(req, res, next)
@@ -124,16 +124,16 @@ describe('Company controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: '' },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('error-message', 'Unable to archive company, no reason given')
         done()
-      }
+      },
     }
 
     companyArchiveController.archiveCompany(req, res, next)
@@ -142,16 +142,16 @@ describe('Company controller, archive', function () {
     const req = {
       session: { token },
       params: {
-        id: company.id
+        id: company.id,
       },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(companyRepositoryUnArchiveCompanyStub).to.be.calledWith(token, company.id)
         done()
-      }
+      },
     }
 
     companyArchiveController.unarchiveCompany(req, res, next)

--- a/test/controllers/company-ch.controller.test.js
+++ b/test/controllers/company-ch.controller.test.js
@@ -33,8 +33,8 @@ describe('Company controller, Companies Houe', function () {
     incorporation_date: '2017-02-15',
     registered_address_country: {
       id: '80756b9a-5d95-e211-a939-e4115bead28a',
-      name: 'United Kingdom'
-    }
+      name: 'United Kingdom',
+    },
   }
 
   beforeEach(function () {
@@ -45,17 +45,17 @@ describe('Company controller, Companies Houe', function () {
 
     companyControllerCh = proxyquire('~/src/controllers/company-ch.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: getInflatedDitCompanyStub
+        getInflatedDitCompany: getInflatedDitCompanyStub,
       },
       '../services/company-formatting.service': {
         getDisplayCompany: getDisplayCompanyStub,
         getDisplayCH: getDisplayCHStub,
         getHeadingName: getHeadingNameStub,
-        getHeadingAddress: getHeadingAddressStub
+        getHeadingAddress: getHeadingAddressStub,
       },
       '../repos/company.repo': {
-        getCHCompany: getCHCompanyStub
-      }
+        getCHCompany: getCHCompanyStub,
+      },
     })
   })
 
@@ -63,17 +63,17 @@ describe('Company controller, Companies Houe', function () {
     it('should get the ch company details', function (done) {
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, {
         locals: {},
         render: function () {
           expect(getCHCompanyStub).to.be.calledWith('1234', '9999')
           done()
-        }
+        },
       }, next)
     })
     it('should return the company heading name and address', function (done) {
@@ -83,16 +83,16 @@ describe('Company controller, Companies Houe', function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
-        }
+        },
       }
 
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get a formatted copy of the company house data to display', function (done) {
@@ -104,16 +104,16 @@ describe('Company controller, Companies Houe', function () {
           expect(res.locals).to.have.property('chDetailsLabels')
           expect(res.locals.chDetailsDisplayOrder).to.deep.equal(['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code'])
           done()
-        }
+        },
       }
 
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should not try and get formatted data for CDMS company details', function (done) {
@@ -123,16 +123,16 @@ describe('Company controller, Companies Houe', function () {
           expect(getDisplayCompanyStub).to.not.be.called
           expect(res.locals).to.not.have.property('companyDetails')
           done()
-        }
+        },
       }
 
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should not provide account management information', function (done) {
@@ -142,16 +142,16 @@ describe('Company controller, Companies Houe', function () {
           expect(res.locals).to.not.have.property('accountManagementDisplay')
           expect(res.locals).to.not.have.property('accountManagementDisplayLabels')
           done()
-        }
+        },
       }
 
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
@@ -160,16 +160,16 @@ describe('Company controller, Companies Houe', function () {
         render: function (template) {
           expect(template).to.equal('company/details-ch')
           done()
-        }
+        },
       }
 
       companyControllerCh.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
   })

--- a/test/controllers/company-contact.controller.test.js
+++ b/test/controllers/company-contact.controller.test.js
@@ -26,7 +26,7 @@ describe('Company contacts controller', function () {
       registered_address_town: 'Windsor',
       registered_address_country: {
         id: '80756b9a-5d95-e211-a939-e4115bead28a',
-        name: 'United Kingdom'
+        name: 'United Kingdom',
       },
       registered_address_county: 'Berkshire',
       registered_address_postcode: 'SL4 4QR',
@@ -50,21 +50,21 @@ describe('Company contacts controller', function () {
       archived_by: null,
       business_type: {
         id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-        name: 'Intermediary'
+        name: 'Intermediary',
       },
       sector: {
         id: 'b722c9d2-5f95-e211-a939-e4115bead28a',
-        name: 'Aerospace : Maintenance'
+        name: 'Aerospace : Maintenance',
       },
       employee_range: null,
       turnover_range: null,
       uk_region: {
         id: '844cd12a-6095-e211-a939-e4115bead28a',
-        name: 'East Midlands'
+        name: 'East Midlands',
       },
       trading_address_country: null,
       headquarter_type: null,
-      classification: null
+      classification: null,
     }
 
     company.contacts = [{
@@ -96,10 +96,10 @@ describe('Company contacts controller', function () {
       archived_by: null,
       title: {
         id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-        name: 'Mr'
+        name: 'Mr',
       },
       advisor: null,
-      address_country: null
+      address_country: null,
     },
     {
       company,
@@ -130,10 +130,10 @@ describe('Company contacts controller', function () {
       archived_by: null,
       title: {
         id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-        name: 'Mr'
+        name: 'Mr',
       },
       advisor: null,
-      address_country: null
+      address_country: null,
     },
     {
       company,
@@ -175,14 +175,14 @@ describe('Company contacts controller', function () {
         enabled: false,
         dit_team: '0167b456-0ddd-49bd-8184-e3227a0b6396',
         groups: [],
-        user_permissions: []
+        user_permissions: [],
       },
       title: {
         id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-        name: 'Mr'
+        name: 'Mr',
       },
       advisor: null,
-      address_country: null
+      address_country: null,
     }]
   })
 
@@ -194,25 +194,25 @@ describe('Company contacts controller', function () {
     beforeEach(function (done) {
       req = {
         session: {},
-        params: { id: '1' }
+        params: { id: '1' },
       }
       res = {
         locals: {
           headingName: 'Freds Company',
           headingAddress: '1234 Road, London, EC1 1AA',
-          id: '44332211'
+          id: '44332211',
         },
         render: function (template, options) {
           locals = Object.assign({}, res.locals, options)
           done()
-        }
+        },
       }
 
       companyContactController = proxyquire('~/src/controllers/company-contact.controller', {
         '../services/company.service': {
           getInflatedDitCompany: sinon.stub().resolves(company),
-          getCommonTitlesAndLinks: sinon.stub()
-        }
+          getCommonTitlesAndLinks: sinon.stub(),
+        },
       })
 
       companyContactController.getContacts(req, res, next)
@@ -263,7 +263,7 @@ describe('Company contacts controller', function () {
         address: '10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
         email_alternative: 'fred@gmail.com',
         notes: 'some notes',
-        telephone_alternative: '07814 000 333'
+        telephone_alternative: '07814 000 333',
       }, {
         url: '/contact/12651151-2149-465e-871b-ac45bc568a63/details',
         name: 'Jane Smith',
@@ -274,7 +274,7 @@ describe('Company contacts controller', function () {
         address: '10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
         email_alternative: 'jane@gmail.com',
         notes: 'some notes',
-        telephone_alternative: '07814 000 333'
+        telephone_alternative: '07814 000 333',
       }]
 
       contactsArchived = [{
@@ -283,7 +283,7 @@ describe('Company contacts controller', function () {
         job_title: 'Director',
         reason: 'Left company',
         archived_by: 'Fred Flintstone',
-        archived_on: '14 Feb 2017'
+        archived_on: '14 Feb 2017',
       }]
 
       addContactUrl = '/contact/add?company=1234'

--- a/test/controllers/company-export.controller.test.js
+++ b/test/controllers/company-export.controller.test.js
@@ -6,7 +6,7 @@ describe('Company export controller', () => {
   beforeEach(() => {
     this.company = Object.assign({}, _company, {
       export_to_countries: [{ id: '1234', name: 'France' }, { id: '2234', name: 'Italy' }],
-      future_interest_countries: [{ id: '4321', name: 'Germany' }]
+      future_interest_countries: [{ id: '4321', name: 'Germany' }],
     })
 
     this.sandbox = sinon.sandbox.create()
@@ -22,21 +22,21 @@ describe('Company export controller', () => {
     this.companyExportController = proxyquire('~/src/controllers/company-export.controller', {
       '../services/company.service': {
         getInflatedDitCompany: this.getInflatedDitCompany,
-        getCommonTitlesAndlinks: this.getCommonTitlesAndlinks
+        getCommonTitlesAndlinks: this.getCommonTitlesAndlinks,
       },
       '../repos/company.repo': {
         getDitCompany: this.getDitCompany,
-        saveCompany: this.saveCompany
+        saveCompany: this.saveCompany,
       },
       '../repos/metadata.repo': {
         countryOptions: [{
           id: '1234',
-          name: 'France'
-        }]
+          name: 'France',
+        }],
       },
       '../lib/controller-utils': {
-        flattenIdFields: this.flattenIdFields
-      }
+        flattenIdFields: this.flattenIdFields,
+      },
     })
   })
 
@@ -49,15 +49,15 @@ describe('Company export controller', () => {
       this.locals = { id: 'test' }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }
 
       const res = {
-        locals: {}
+        locals: {},
       }
 
       return this.companyExportController.common(req, res)
@@ -69,15 +69,15 @@ describe('Company export controller', () => {
       this.locals = { id: 'test' }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }
 
       const res = {
-        locals: {}
+        locals: {},
       }
 
       return this.companyExportController.common(req, res)
@@ -90,15 +90,15 @@ describe('Company export controller', () => {
       this.locals = { id: 'test' }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }
 
       const res = {
-        locals: {}
+        locals: {},
       }
 
       return this.companyExportController.common(req, res)
@@ -112,22 +112,22 @@ describe('Company export controller', () => {
     it('should return a list of countries currently exporting to and want to export to', (done) => {
       this.companyExportController.view({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }, {
         locals: {
-          company: this.company
+          company: this.company,
         },
         render: (template, data) => {
           expect(data.exportDetails).to.deep.equal({
             exportToCountries: 'France, Italy',
-            futureInterestCountries: 'Germany'
+            futureInterestCountries: 'Germany',
           })
           done()
-        }
+        },
       }, this.next)
     })
 
@@ -135,33 +135,33 @@ describe('Company export controller', () => {
       this.company.export_to_countries = []
       this.companyExportController = proxyquire('~/src/controllers/company-export.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: this.getInflatedDitCompany
+          getInflatedDitCompany: this.getInflatedDitCompany,
         },
         '../repos/metadata.repo': {
           getDitcompany: this.getDitCompany,
-          saveCompany: this.saveCompany
+          saveCompany: this.saveCompany,
         },
         '../lib/controller-utils': {
-          flattenIdFields: this.flattenIdFields
-        }
+          flattenIdFields: this.flattenIdFields,
+        },
       })
 
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }
       const res = {
         locals: {
-          company: this.company
+          company: this.company,
         },
         render: (template, data) => {
           expect(data.exportDetails.exportToCountries).to.equal('')
           done()
-        }
+        },
       }
 
       this.companyExportController.view(req, res, this.next)
@@ -170,20 +170,20 @@ describe('Company export controller', () => {
     it('should include display order and labels', (done) => {
       this.companyExportController.view({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
-        }
+          id: this.company.id,
+        },
       }, {
         locals: {
-          company: this.company
+          company: this.company,
         },
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsDisplayOrder')
           expect(data).to.have.property('exportDetailsLabels')
           done()
-        }
+        },
       }, this.next)
     })
   })
@@ -195,58 +195,58 @@ describe('Company export controller', () => {
 
       this.companyExportController.edit({
         session: {
-          token: '1234'
+          token: '1234',
         },
         body: {
           export_to_countries,
-          future_interest_countries
+          future_interest_countries,
         },
         params: {
-          id: '1234'
-        }
+          id: '1234',
+        },
       }, {
         locals: {},
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(export_to_countries)
           expect(data.future_interest_countries).to.deep.equal(future_interest_countries)
           done()
-        }
+        },
       }, this.next)
     })
 
     it('parse company export data into a form format if called for first time', (done) => {
       this.companyExportController.edit({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
-        body: {}
+        body: {},
       }, {
         locals: {
-          company: this.company
+          company: this.company,
         },
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['1234', '2234'])
           expect(data.future_interest_countries).to.deep.equal(['4321'])
           done()
-        }
+        },
       }, this.next)
     })
 
     it('should include labels', (done) => {
       this.companyExportController.edit({
         session: { token: '1234' },
-        params: { id: '1234' }
+        params: { id: '1234' },
       }, {
         locals: {
-          company: this.company
+          company: this.company,
         },
         render: (template, data) => {
           expect(data).to.have.property('exportDetailsLabels')
           done()
-        }
+        },
       }, this.next)
     })
   })
@@ -255,16 +255,16 @@ describe('Company export controller', () => {
     it('should get the existing company and flatten it pass back with export data', (done) => {
       this.companyExportController.post({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries: ['888', '333'],
-          future_interest_countries: ['555', '666']
-        }
+          future_interest_countries: ['555', '666'],
+        },
       }, {
         locals: {},
         redirect: (url) => {
@@ -278,7 +278,7 @@ describe('Company export controller', () => {
           expect(firstCallArgs).to.have.property('export_to_countries')
           expect(firstCallArgs).to.have.property('future_interest_countries')
           done()
-        }
+        },
       }, this.next)
     })
 
@@ -288,16 +288,16 @@ describe('Company export controller', () => {
 
       this.companyExportController.post({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries,
-          future_interest_countries
-        }
+          future_interest_countries,
+        },
       }, {
         locals: {},
         redirect: (url) => {
@@ -305,7 +305,7 @@ describe('Company export controller', () => {
           expect(firstCallArgs.export_to_countries).to.deep.equal(export_to_countries)
           expect(firstCallArgs.future_interest_countries).to.deep.equal(future_interest_countries)
           done()
-        }
+        },
       }, this.next)
     })
 
@@ -315,22 +315,22 @@ describe('Company export controller', () => {
 
       this.companyExportController.post({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries,
-          future_interest_countries
-        }
+          future_interest_countries,
+        },
       }, {
         locals: {},
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].future_interest_countries).to.be.deep.equal(['4321'])
           done()
-        }
+        },
       }, this.next)
     })
 
@@ -341,19 +341,19 @@ describe('Company export controller', () => {
       this.companyExportController.post({
         session: { token: '1234' },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries,
-          future_interest_countries
-        }
+          future_interest_countries,
+        },
       }, {
         locals: {},
         redirect: (url) => {
           expect(this.saveCompany.firstCall.args[1].export_to_countries).to.deep.equal(['1234'])
           done()
-        }
+        },
       }, this.next)
     })
 
@@ -361,21 +361,21 @@ describe('Company export controller', () => {
       const error = new Error('error')
       this.companyExportController = proxyquire('~/src/controllers/company-export.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: this.getInflatedDitCompany
+          getInflatedDitCompany: this.getInflatedDitCompany,
         },
         '../repos/company.repo': {
           getDitCompany: this.getDitCompany,
-          saveCompany: this.saveCompany
+          saveCompany: this.saveCompany,
         },
         '../repos/metadata.repo': {
           countryOptions: [{
             id: '1234',
-            name: 'France'
-          }]
+            name: 'France',
+          }],
         },
         '../lib/controller-utils': {
-          flattenIdFields: this.flattenIdFields
-        }
+          flattenIdFields: this.flattenIdFields,
+        },
       })
 
       this.companyExportController.post({
@@ -384,10 +384,10 @@ describe('Company export controller', () => {
         body: {
           id: this.company.id,
           export_to_countries: ['1234', '3211'],
-          future_interest_countries: '4321'
-        }
+          future_interest_countries: '4321',
+        },
       }, {
-        locals: {}
+        locals: {},
       }, (_error) => {
         expect(_error).to.deep.equal(error)
         done()
@@ -397,46 +397,46 @@ describe('Company export controller', () => {
     it('should add a new export to country when instructed to', (done) => {
       this.companyExportController.post({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries: ['888', '333'],
           future_interest_countries: ['555', '666'],
-          addExportToCountry: 'Add country'
-        }
+          addExportToCountry: 'Add country',
+        },
       }, {
         locals: {},
         render: (template, data) => {
           expect(data.export_to_countries).to.deep.equal(['888', '333', ''])
           done()
-        }
+        },
       }, this.next)
     })
 
     it('should add a new future interest country when instructed to', (done) => {
       this.companyExportController.post({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: this.company.id
+          id: this.company.id,
         },
         body: {
           id: this.company.id,
           export_to_countries: ['888', '333'],
           future_interest_countries: ['555', '666'],
-          addFutureInterestCountry: 'Add country'
-        }
+          addFutureInterestCountry: 'Add country',
+        },
       }, {
         locals: {},
         render: (template, data) => {
           expect(data.future_interest_countries).to.deep.equal(['555', '666', ''])
           done()
-        }
+        },
       }, this.next)
     })
   })

--- a/test/controllers/company-foreign.controller.test.js
+++ b/test/controllers/company-foreign.controller.test.js
@@ -23,7 +23,7 @@ describe('Company controller, foreign', function () {
     name: 'Freds ltd',
     business_type: {
       id: '43134234',
-      name: 'Charity'
+      name: 'Charity',
     },
     registered_address_1: '13 HOWICK PARK AVENUE',
     registered_address_2: 'PENWORTHAM',
@@ -31,7 +31,7 @@ describe('Company controller, foreign', function () {
     registered_address_4: null,
     registered_address_town: 'PRESTON',
     registered_address_county: '',
-    registered_address_postcode: 'PR1 0LS'
+    registered_address_postcode: 'PR1 0LS',
   }
   const metadataRepositoryStub = {
     regionOptions: [{ id: '1', name: 'option 1' }],
@@ -43,8 +43,8 @@ describe('Company controller, foreign', function () {
     headquarterOptions: [
       { id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b', name: 'ehq' },
       { id: '43281c5e-92a4-4794-867b-b4d5f801e6f3', name: 'ghq' },
-      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' }
-    ]
+      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' },
+    ],
   }
 
   beforeEach(function () {
@@ -60,21 +60,21 @@ describe('Company controller, foreign', function () {
 
     companyControllerForeign = proxyquire('~/src/controllers/company-foreign.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: getInflatedDitCompanyStub
+        getInflatedDitCompany: getInflatedDitCompanyStub,
       },
       '../services/company-formatting.service': {
         getDisplayCompany: getDisplayCompanyStub,
-        getDisplayCH: getDisplayCHStub
+        getDisplayCH: getDisplayCHStub,
       },
       '../services/company-form.service': {
         getForeignCompanyAsFormData: getForeignCompanyAsFormDataStub,
-        saveCompanyForm: saveCompanyFormStub
+        saveCompanyForm: saveCompanyFormStub,
       },
       '../repos/company.repo': {
         getCHCompany: getCHCompanyStub,
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
-      '../repos/metadata.repo': metadataRepositoryStub
+      '../repos/metadata.repo': metadataRepositoryStub,
     })
   })
 
@@ -82,17 +82,17 @@ describe('Company controller, foreign', function () {
     it('should get the company details', function (done) {
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, {
         locals: {},
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
-        }
+        },
       }, next)
     })
     it('should return the company heading name and address', function (done) {
@@ -102,16 +102,16 @@ describe('Company controller, foreign', function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
-        }
+        },
       }
 
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get not get a formatted copy of the company house data to display', function (done) {
@@ -123,16 +123,16 @@ describe('Company controller, foreign', function () {
           expect(res.locals).to.not.have.property('chDetailsLabels')
           expect(res.locals).to.not.have.property('chDetailsDisplayOrder')
           done()
-        }
+        },
       }
 
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
@@ -144,16 +144,16 @@ describe('Company controller, foreign', function () {
           expect(res.locals).to.have.property('companyDetailsLabels')
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['business_type', 'registered_address', 'alias', 'trading_address', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
-        }
+        },
       }
 
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should provide account management information', function (done) {
@@ -163,16 +163,16 @@ describe('Company controller, foreign', function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
-        }
+        },
       }
 
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
@@ -181,16 +181,16 @@ describe('Company controller, foreign', function () {
         render: function (template) {
           expect(template).to.equal('company/details-foreign')
           done()
-        }
+        },
       }
 
       companyControllerForeign.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
   })
@@ -199,35 +199,35 @@ describe('Company controller, foreign', function () {
       const req = {
         session: { token: '1234' },
         query: { business_type: 'charity' },
-        params: {}
+        params: {},
       }
       const res = {
         locals: {},
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
-        }
+        },
       }
 
       companyControllerForeign.addDetails(req, res, next)
     })
     it('should pass an populated form if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { id: '00112233' },
         query: { business_type: 'charity' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerForeign.addDetails(req, res, next)
@@ -236,14 +236,14 @@ describe('Company controller, foreign', function () {
       const req = {
         session: { token: '1234' },
         query: { business_type: 'charity' },
-        params: { id: '00112233' }
+        params: { id: '00112233' },
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-foreign')
           done()
-        }
+        },
       }
 
       companyControllerForeign.addDetails(req, res, next)
@@ -281,7 +281,7 @@ describe('Company controller, foreign', function () {
         website: 'https://www.test.com',
         description: 'This is a test',
         employee_range: '1',
-        turnover_range: '1'
+        turnover_range: '1',
       }
 
       return render('../../src/views/company/edit-foreign.njk', {
@@ -292,7 +292,7 @@ describe('Company controller, foreign', function () {
         headquarterOptions: metadataRepositoryStub.headquarterOptions,
         countryOptions: metadataRepositoryStub.countryOptions,
         hqLabels,
-        formData
+        formData,
       })
       .then((_document) => {
         document = _document
@@ -332,7 +332,7 @@ describe('Company controller, foreign', function () {
     it('should translate a company record into form data if no body posted', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { id: '9999' }
+        params: { id: '9999' },
       }
       const res = {
         locals: {},
@@ -341,20 +341,20 @@ describe('Company controller, foreign', function () {
           expect(getForeignCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
-        }
+        },
       }
 
       companyControllerForeign.editDetails(req, res, next)
     })
     it('should pass through form data if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -362,27 +362,27 @@ describe('Company controller, foreign', function () {
           expect(getForeignCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerForeign.editDetails(req, res, next)
     })
     it('should render with the correct template', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-foreign')
           done()
-        }
+        },
       }
 
       companyControllerForeign.editDetails(req, res, next)
@@ -393,14 +393,14 @@ describe('Company controller, foreign', function () {
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
-        }
+        },
       }
 
       companyControllerForeign.editDetails(req, res, next)
@@ -411,14 +411,14 @@ describe('Company controller, foreign', function () {
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
-        }
+        },
       }
 
       companyControllerForeign.editDetails(req, res, next)
@@ -428,14 +428,14 @@ describe('Company controller, foreign', function () {
     it('call the company repository to save the company', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -445,21 +445,21 @@ describe('Company controller, foreign', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -469,46 +469,46 @@ describe('Company controller, foreign', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
       saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] }
+        errors: { name: ['test'] },
       })
 
       companyControllerForeign = proxyquire('~/src/controllers/company-foreign.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: getInflatedDitCompanyStub
+          getInflatedDitCompany: getInflatedDitCompanyStub,
         },
         '../services/company-formatting.service': {
           getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub
+          getDisplayCH: getDisplayCHStub,
         },
         '../services/company-form.service': {
           getForeignCompanyAsFormData: getForeignCompanyAsFormDataStub,
-          saveCompanyForm: saveCompanyFormStub
+          saveCompanyForm: saveCompanyFormStub,
         },
         '../repos/company.repo': {
           getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
-        '../repos/metadata.repo': metadataRepositoryStub
+        '../repos/metadata.repo': metadataRepositoryStub,
       })
 
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         query: { business_type: 'charity' },
         params: {},
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -519,21 +519,21 @@ describe('Company controller, foreign', function () {
           expect(template).to.equal('company/edit-foreign')
           expect(res.locals).to.have.property('errors')
           done()
-        }
+        },
       }
       companyControllerForeign.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -543,7 +543,7 @@ describe('Company controller, foreign', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerForeign.postDetails(req, res, next)
     })
@@ -555,11 +555,11 @@ describe('Company controller, foreign', function () {
     beforeEach(function () {
       req = {
         session: {
-          token: '1234'
-        }
+          token: '1234',
+        },
       }
       res = {
-        locals: {}
+        locals: {},
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/controllers/company-interaction.controller.test.js
+++ b/test/controllers/company-interaction.controller.test.js
@@ -18,18 +18,18 @@ describe('Company interactions controller', function () {
         interaction_type: { id: '1234', name: 'Email' },
         subject: 'Subject 1234',
         date: '2017-02-14T14:49:17',
-        dit_advisor: { first_name: 'Fred', last_name: 'Smith' }
+        dit_advisor: { first_name: 'Fred', last_name: 'Smith' },
       }, {
         id: '22651151-2149-465e-871b-ac45bc568a63',
         interaction_type: { id: '1234', name: 'Service delivery' },
         subject: 'Subject 1234',
         date: '2017-02-14T14:49:17',
-        dit_advisor: { first_name: 'Fred', last_name: 'Smith' }
+        dit_advisor: { first_name: 'Fred', last_name: 'Smith' },
       }],
       contacts: [
         { id: '12651151-2149-465e-871b-ac45bc568a62' },
         { id: '12651151-2149-465e-871b-ac45bc568a63' },
-        { id: '12651151-2149-465e-871b-ac45bc568a64' }
+        { id: '12651151-2149-465e-871b-ac45bc568a64' },
       ],
       export_to_countries: [],
       future_interest_countries: [],
@@ -42,7 +42,7 @@ describe('Company interactions controller', function () {
       registered_address_town: 'Windsor',
       registered_address_country: {
         id: '80756b9a-5d95-e211-a939-e4115bead28a',
-        name: 'United Kingdom'
+        name: 'United Kingdom',
       },
       registered_address_county: 'Berkshire',
       registered_address_postcode: 'SL4 4QR',
@@ -66,26 +66,26 @@ describe('Company interactions controller', function () {
       archived_by: null,
       business_type: {
         id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-        name: 'Intermediary'
+        name: 'Intermediary',
       },
       sector: {
         id: 'b722c9d2-5f95-e211-a939-e4115bead28a',
-        name: 'Aerospace : Maintenance'
+        name: 'Aerospace : Maintenance',
       },
       employee_range: null,
       turnover_range: null,
       uk_region: {
         id: '844cd12a-6095-e211-a939-e4115bead28a',
-        name: 'East Midlands'
+        name: 'East Midlands',
       },
       trading_address_country: null,
       headquarter_type: null,
-      classification: null
+      classification: null,
     }
     companyinteractioncontroller = proxyquire('~/src/controllers/company-interaction.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: sinon.stub().resolves(company)
-      }
+        getInflatedDitCompany: sinon.stub().resolves(company),
+      },
     })
   })
 
@@ -93,7 +93,7 @@ describe('Company interactions controller', function () {
     it('should return a list of interactions', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { id: '1' }
+        params: { id: '1' },
       }
       const res = {
         locals: {},
@@ -101,21 +101,21 @@ describe('Company interactions controller', function () {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(2)
           done()
-        }
+        },
       }
       companyinteractioncontroller.getInteractions(req, res, next)
     })
     it('should return a url to add interactions if a valid company and has contacts', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { id: '1' }
+        params: { id: '1' },
       }
       const res = {
         locals: {},
         render: function (template, options) {
           expect(res.locals).to.have.property('addInteractionUrl')
           done()
-        }
+        },
       }
       companyinteractioncontroller.getInteractions(req, res, next)
     })
@@ -124,19 +124,19 @@ describe('Company interactions controller', function () {
       company.companies_house_data = { name: 'Fred' }
       companyinteractioncontroller = proxyquire('~/src/controllers/company-interaction.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: sinon.stub().resolves(company)
-        }
+          getInflatedDitCompany: sinon.stub().resolves(company),
+        },
       })
       const req = {
         session: { token: '1234' },
-        params: { id: '1' }
+        params: { id: '1' },
       }
       const res = {
         locals: {},
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()
-        }
+        },
       }
       companyinteractioncontroller.getInteractions(req, res, next)
     })
@@ -144,19 +144,19 @@ describe('Company interactions controller', function () {
       company.contacts = []
       companyinteractioncontroller = proxyquire('~/src/controllers/company-interaction.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: sinon.stub().resolves(company)
-        }
+          getInflatedDitCompany: sinon.stub().resolves(company),
+        },
       })
       const req = {
         session: { token: '1234' },
-        params: { id: '1' }
+        params: { id: '1' },
       }
       const res = {
         locals: {},
         render: function (template, options) {
           expect(res.locals).to.not.have.property('addInteractionUrl')
           done()
-        }
+        },
       }
       companyinteractioncontroller.getInteractions(req, res, next)
     })
@@ -173,14 +173,14 @@ describe('Company interactions controller', function () {
         subject: 'Test subject',
         date: '23 February 2017',
         advisor: 'Fred Smith',
-        contact: 'Jim Brown'
+        contact: 'Jim Brown',
       }, {
         url: '/servicedelivery/2/details',
         interaction_type: 'Service Delivery',
         subject: 'Test subject',
         date: '23 February 2017',
         advisor: 'Fred Smith',
-        contact: 'Simon Carter'
+        contact: 'Simon Carter',
       }]
 
       addInteractionUrl = '/interaction/add?company=1234'

--- a/test/controllers/company-ltd.controller.test.js
+++ b/test/controllers/company-ltd.controller.test.js
@@ -41,8 +41,8 @@ describe('Company controller, ltd', function () {
     incorporation_date: '2017-02-15',
     registered_address_country: {
       id: '80756b9a-5d95-e211-a939-e4115bead28a',
-      name: 'United Kingdom'
-    }
+      name: 'United Kingdom',
+    },
   }
   const company = {
     id: '9999',
@@ -55,7 +55,7 @@ describe('Company controller, ltd', function () {
     registered_address_4: null,
     registered_address_town: 'PRESTON',
     registered_address_county: '',
-    registered_address_postcode: 'PR1 0LS'
+    registered_address_postcode: 'PR1 0LS',
   }
   const metadataRepositoryStub = {
     regionOptions: [{ id: '1', name: 'option 1' }],
@@ -66,8 +66,8 @@ describe('Company controller, ltd', function () {
     headquarterOptions: [
       { id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b', name: 'ehq' },
       { id: '43281c5e-92a4-4794-867b-b4d5f801e6f3', name: 'ghq' },
-      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' }
-    ]
+      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' },
+    ],
   }
 
   beforeEach(function () {
@@ -84,22 +84,22 @@ describe('Company controller, ltd', function () {
 
     companyControllerLtd = proxyquire('~/src/controllers/company-ltd.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: getInflatedDitCompanyStub
+        getInflatedDitCompany: getInflatedDitCompanyStub,
       },
       '../services/company-formatting.service': {
         getDisplayCompany: getDisplayCompanyStub,
-        getDisplayCH: getDisplayCHStub
+        getDisplayCH: getDisplayCHStub,
       },
       '../repos/company.repo': {
         getCHCompany: getCHCompanyStub,
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
       '../services/company-form.service': {
         getLtdCompanyAsFormData: getLtdCompanyAsFormDataStub,
         getDefaultLtdFormForCH: getDefaultLtdFormForCHStub,
-        saveCompanyForm: saveCompanyFormStub
+        saveCompanyForm: saveCompanyFormStub,
       },
-      '../repos/metadata.repo': metadataRepositoryStub
+      '../repos/metadata.repo': metadataRepositoryStub,
     })
   })
 
@@ -107,17 +107,17 @@ describe('Company controller, ltd', function () {
     it('should get the company details', function (done) {
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, {
         locals: {},
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
-        }
+        },
       }, next)
     })
     it('should return the company heading name and address', function (done) {
@@ -127,16 +127,16 @@ describe('Company controller, ltd', function () {
           expect(res.locals.headingName).to.equal('ADALEOP LTD')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
-        }
+        },
       }
 
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get a formatted copy of the company house data to display', function (done) {
@@ -148,16 +148,16 @@ describe('Company controller, ltd', function () {
           expect(res.locals).to.have.property('chDetailsLabels')
           expect(res.locals.chDetailsDisplayOrder).to.deep.equal(['name', 'company_number', 'registered_address', 'business_type', 'company_status', 'incorporation_date', 'sic_code'])
           done()
-        }
+        },
       }
 
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
@@ -169,16 +169,16 @@ describe('Company controller, ltd', function () {
           expect(res.locals).to.have.property('companyDetailsLabels')
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['alias', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
-        }
+        },
       }
 
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should provide account management information', function (done) {
@@ -188,16 +188,16 @@ describe('Company controller, ltd', function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
-        }
+        },
       }
 
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should use a template for ltd data', function (done) {
@@ -206,16 +206,16 @@ describe('Company controller, ltd', function () {
         render: function (template) {
           expect(template).to.equal('company/details-ltd')
           done()
-        }
+        },
       }
 
       companyControllerLtd.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
   })
@@ -223,7 +223,7 @@ describe('Company controller, ltd', function () {
     it('should create form defaults for an empty company', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { company_number: '00112233' }
+        params: { company_number: '00112233' },
       }
       const res = {
         locals: {},
@@ -231,27 +231,27 @@ describe('Company controller, ltd', function () {
           expect(getDefaultLtdFormForCHStub).to.be.calledWith(chCompany)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
-        }
+        },
       }
 
       companyControllerLtd.addDetails(req, res, next)
     })
     it('should pass an populated form if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerLtd.addDetails(req, res, next)
@@ -259,7 +259,7 @@ describe('Company controller, ltd', function () {
     it('should load CH details to populate defaults', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { company_number: '00112233' }
+        params: { company_number: '00112233' },
       }
       const res = {
         locals: {},
@@ -269,7 +269,7 @@ describe('Company controller, ltd', function () {
           expect(res.locals).to.have.property('chCompany')
           expect(res.locals).to.have.property('chDetails')
           done()
-        }
+        },
       }
 
       companyControllerLtd.addDetails(req, res, next)
@@ -277,14 +277,14 @@ describe('Company controller, ltd', function () {
     it('should render with the correct template', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { company_number: '00112233' }
+        params: { company_number: '00112233' },
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-ltd')
           done()
-        }
+        },
       }
 
       companyControllerLtd.addDetails(req, res, next)
@@ -302,7 +302,7 @@ describe('Company controller, ltd', function () {
         name: 'Amazon Savers',
         company_status: 'Active',
         sic_code: ['82990 - Other business support service activities n.e.c.', '82991 - Other business support service activities n.e.c.'],
-        incorporation_date: '6 February 2012'
+        incorporation_date: '6 February 2012',
       }
 
       formData = {
@@ -331,7 +331,7 @@ describe('Company controller, ltd', function () {
         website: 'https://www.test.com',
         description: 'This is a test',
         employee_range: '1',
-        turnover_range: '1'
+        turnover_range: '1',
       }
 
       return render('../../src/views/company/edit-ltd.njk', {
@@ -344,7 +344,7 @@ describe('Company controller, ltd', function () {
         hqLabels,
         formData,
         chCompany,
-        chDetails
+        chDetails,
       })
       .then((_document) => {
         document = _document
@@ -389,7 +389,7 @@ describe('Company controller, ltd', function () {
     it('should translate a company record into form data if no body posted', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { id: '9999' }
+        params: { id: '9999' },
       }
       const res = {
         locals: {},
@@ -398,20 +398,20 @@ describe('Company controller, ltd', function () {
           expect(getLtdCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
-        }
+        },
       }
 
       companyControllerLtd.editDetails(req, res, next)
     })
     it('should pass through form data if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -420,27 +420,27 @@ describe('Company controller, ltd', function () {
           expect(getLtdCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerLtd.editDetails(req, res, next)
     })
     it('should render with the correct template', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-ltd')
           done()
-        }
+        },
       }
 
       companyControllerLtd.editDetails(req, res, next)
@@ -451,14 +451,14 @@ describe('Company controller, ltd', function () {
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
-        }
+        },
       }
 
       companyControllerLtd.editDetails(req, res, next)
@@ -469,14 +469,14 @@ describe('Company controller, ltd', function () {
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
-        }
+        },
       }
 
       companyControllerLtd.editDetails(req, res, next)
@@ -486,14 +486,14 @@ describe('Company controller, ltd', function () {
     it('call the company repository to save the company', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -503,21 +503,21 @@ describe('Company controller, ltd', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -527,46 +527,46 @@ describe('Company controller, ltd', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
       saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] }
+        errors: { name: ['test'] },
       })
 
       companyControllerLtd = proxyquire('~/src/controllers/company-ltd.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: getInflatedDitCompanyStub
+          getInflatedDitCompany: getInflatedDitCompanyStub,
         },
         '../services/company-formatting.service': {
           getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub
+          getDisplayCH: getDisplayCHStub,
         },
         '../repos/company.repo': {
           getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../services/company-form.service': {
           getLtdCompanyAsFormData: getLtdCompanyAsFormDataStub,
           getDefaultLtdFormForCH: getDefaultLtdFormForCHStub,
-          saveCompanyForm: saveCompanyFormStub
+          saveCompanyForm: saveCompanyFormStub,
         },
-        '../repos/metadata.repo': metadataRepositoryStub
+        '../repos/metadata.repo': metadataRepositoryStub,
       })
 
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {},
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -577,21 +577,21 @@ describe('Company controller, ltd', function () {
           expect(template).to.equal('company/edit-ltd')
           expect(res.locals).to.have.property('errors')
           done()
-        }
+        },
       }
       companyControllerLtd.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -601,7 +601,7 @@ describe('Company controller, ltd', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerLtd.postDetails(req, res, next)
     })
@@ -613,11 +613,11 @@ describe('Company controller, ltd', function () {
     beforeEach(function () {
       req = {
         session: {
-          token: '1234'
-        }
+          token: '1234',
+        },
       }
       res = {
-        locals: {}
+        locals: {},
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/controllers/company-ukother.controller.test.js
+++ b/test/controllers/company-ukother.controller.test.js
@@ -22,7 +22,7 @@ describe('Company controller, uk other', function () {
     copanies_house_data: null,
     business_type: {
       id: '43134234',
-      name: 'Charity'
+      name: 'Charity',
     },
     name: 'Freds ltd',
     registered_address_1: '13 HOWICK PARK AVENUE',
@@ -31,7 +31,7 @@ describe('Company controller, uk other', function () {
     registered_address_4: null,
     registered_address_town: 'PRESTON',
     registered_address_county: '',
-    registered_address_postcode: 'PR1 0LS'
+    registered_address_postcode: 'PR1 0LS',
   }
   const metadataRepositoryStub = {
     regionOptions: [{ id: '1', name: 'option 1' }],
@@ -43,8 +43,8 @@ describe('Company controller, uk other', function () {
     headquarterOptions: [
       { id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b', name: 'ehq' },
       { id: '43281c5e-92a4-4794-867b-b4d5f801e6f3', name: 'ghq' },
-      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' }
-    ]
+      { id: '3e6debb4-1596-40c5-aa25-f00da0e05af9', name: 'ukhq' },
+    ],
   }
 
   beforeEach(function () {
@@ -60,21 +60,21 @@ describe('Company controller, uk other', function () {
 
     companyControllerUkOther = proxyquire('~/src/controllers/company-ukother.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: getInflatedDitCompanyStub
+        getInflatedDitCompany: getInflatedDitCompanyStub,
       },
       '../services/company-formatting.service': {
         getDisplayCompany: getDisplayCompanyStub,
-        getDisplayCH: getDisplayCHStub
+        getDisplayCH: getDisplayCHStub,
       },
       '../services/company-form.service': {
         getUkOtherCompanyAsFormData: getUkOtherCompanyAsFormDataStub,
-        saveCompanyForm: saveCompanyFormStub
+        saveCompanyForm: saveCompanyFormStub,
       },
       '../repos/company.repo': {
         getCHCompany: getCHCompanyStub,
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
-      '../repos/metadata.repo': metadataRepositoryStub
+      '../repos/metadata.repo': metadataRepositoryStub,
     })
   })
 
@@ -82,17 +82,17 @@ describe('Company controller, uk other', function () {
     it('should get the company details', function (done) {
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, {
         locals: {},
         render: function () {
           expect(getInflatedDitCompanyStub).to.be.calledWith('1234', '9999')
           done()
-        }
+        },
       }, next)
     })
     it('should return the company heading name and address', function (done) {
@@ -102,16 +102,16 @@ describe('Company controller, uk other', function () {
           expect(res.locals.headingName).to.equal('Freds ltd')
           expect(res.locals.headingAddress).to.equal('13 Howick Park Avenue, Penwortham, Preston, PR1 0LS, United Kingdom')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get not get a formatted copy of the company house data to display', function (done) {
@@ -123,16 +123,16 @@ describe('Company controller, uk other', function () {
           expect(res.locals).to.not.have.property('chDetailsLabels')
           expect(res.locals).to.not.have.property('chDetailsDisplayOrder')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should get formatted data for CDMS company details', function (done) {
@@ -144,16 +144,16 @@ describe('Company controller, uk other', function () {
           expect(res.locals).to.have.property('companyDetailsLabels')
           expect(res.locals.companyDetailsDisplayOrder).to.deep.equal(['business_type', 'registered_address', 'alias', 'trading_address', 'uk_region', 'headquarter_type', 'sector', 'website', 'description', 'employee_range', 'turnover_range'])
           done()
-        }
+        },
       }
 
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should provide account management information', function (done) {
@@ -163,16 +163,16 @@ describe('Company controller, uk other', function () {
           expect(res.locals).to.have.property('accountManagementDisplay')
           expect(res.locals).to.have.property('accountManagementDisplayLabels')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
     it('should use a template for ch data', function (done) {
@@ -181,17 +181,17 @@ describe('Company controller, uk other', function () {
         render: function (template) {
           expect(template).to.equal('company/details-ukother')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.getDetails({
         session: {
-          token: '1234'
+          token: '1234',
         },
         query: { business_type: 'charity' },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }, res, next)
     })
   })
@@ -200,35 +200,35 @@ describe('Company controller, uk other', function () {
       const req = {
         session: { token: '1234' },
         params: {},
-        query: { business_type: 'charity' }
+        query: { business_type: 'charity' },
       }
       const res = {
         locals: {},
         render: function () {
           expect(res.locals.formData).to.deep.equal({ business_type: '1' })
           done()
-        }
+        },
       }
 
       companyControllerUkOther.addDetails(req, res, next)
     })
     it('should pass an populated form if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { id: '00112233' },
         query: { business_type: 'charity' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function () {
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerUkOther.addDetails(req, res, next)
@@ -237,14 +237,14 @@ describe('Company controller, uk other', function () {
       const req = {
         session: { token: '1234' },
         params: { id: '00112233' },
-        query: { business_type: 'charity' }
+        query: { business_type: 'charity' },
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-ukother')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.addDetails(req, res, next)
@@ -282,7 +282,7 @@ describe('Company controller, uk other', function () {
         website: 'https://www.test.com',
         description: 'This is a test',
         employee_range: '1',
-        turnover_range: '1'
+        turnover_range: '1',
       }
 
       return render('../../src/views/company/edit-ukother.njk', {
@@ -293,7 +293,7 @@ describe('Company controller, uk other', function () {
         headquarterOptions: metadataRepositoryStub.headquarterOptions,
         countryOptions: metadataRepositoryStub.countryOptions,
         hqLabels,
-        formData
+        formData,
       })
       .then((_document) => {
         document = _document
@@ -335,7 +335,7 @@ describe('Company controller, uk other', function () {
       const req = {
         session: { token: '1234' },
         params: { id: '9999' },
-        query: { business_type: 'charity' }
+        query: { business_type: 'charity' },
       }
       const res = {
         locals: {},
@@ -344,21 +344,21 @@ describe('Company controller, uk other', function () {
           expect(getUkOtherCompanyAsFormDataStub).to.be.calledWith(company)
           expect(res.locals.formData).to.deep.equal(fakeCompanyForm)
           done()
-        }
+        },
       }
 
       companyControllerUkOther.editDetails(req, res, next)
     })
     it('should pass through form data if called with errors', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
         query: { business_type: 'charity' },
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -366,30 +366,30 @@ describe('Company controller, uk other', function () {
           expect(getUkOtherCompanyAsFormDataStub).to.not.be.called
           expect(res.locals.formData).to.deep.equal(body)
           done()
-        }
+        },
       }
 
       companyControllerUkOther.editDetails(req, res, next)
     })
     it('should render with the correct template', function (done) {
       const body = {
-        sector: '1234'
+        sector: '1234',
       }
 
       const req = {
         session: { token: '1234' },
         params: { company_number: '00112233' },
         query: {
-          business_type: 'Charity'
+          business_type: 'Charity',
         },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(template).to.equal('company/edit-ukother')
           done()
-        }
+        },
       }
 
       companyControllerUkOther.editDetails(req, res, next)
@@ -401,14 +401,14 @@ describe('Company controller, uk other', function () {
         session: { token: '1234' },
         params: { company_number: '00112233' },
         query: { business_type: 'charity' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(true)
           done()
-        }
+        },
       }
 
       companyControllerUkOther.editDetails(req, res, next)
@@ -420,14 +420,14 @@ describe('Company controller, uk other', function () {
         session: { token: '1234' },
         params: { company_number: '00112233' },
         query: { business_type: 'charity' },
-        body
+        body,
       }
       const res = {
         locals: {},
         render: function (template) {
           expect(res.locals.showTradingAddress).to.equal(false)
           done()
-        }
+        },
       }
 
       companyControllerUkOther.editDetails(req, res, next)
@@ -437,15 +437,15 @@ describe('Company controller, uk other', function () {
     it('call the company repository to save the company', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         query: { business_type: 'charity' },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -455,22 +455,22 @@ describe('Company controller, uk other', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should forward to the detail screen if save is good', function (done) {
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         query: { business_type: 'charity' },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -480,48 +480,48 @@ describe('Company controller, uk other', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should re-render the edit form with form data on error', function (done) {
       saveCompanyFormStub = sinon.stub().rejects({
-        errors: { name: ['test'] }
+        errors: { name: ['test'] },
       })
 
       companyControllerUkOther = proxyquire('~/src/controllers/company-ukother.controller', {
         '../services/company.service': {
-          getInflatedDitCompany: getInflatedDitCompanyStub
+          getInflatedDitCompany: getInflatedDitCompanyStub,
         },
         '../services/company-formatting.service': {
           getDisplayCompany: getDisplayCompanyStub,
-          getDisplayCH: getDisplayCHStub
+          getDisplayCH: getDisplayCHStub,
         },
         '../services/company-form.service': {
           getUkOtherCompanyAsFormData: getUkOtherCompanyAsFormDataStub,
-          saveCompanyForm: saveCompanyFormStub
+          saveCompanyForm: saveCompanyFormStub,
         },
         '../repos/company.repo': {
           getCHCompany: getCHCompanyStub,
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
-        '../repos/metadata.repo': metadataRepositoryStub
+        '../repos/metadata.repo': metadataRepositoryStub,
       })
 
       const body = {
         id: '999',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {},
         query: {
-          business_type: 'Charity'
+          business_type: 'Charity',
         },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -532,22 +532,22 @@ describe('Company controller, uk other', function () {
           expect(template).to.equal('company/edit-ukother')
           expect(res.locals).to.have.property('errors')
           done()
-        }
+        },
       }
       companyControllerUkOther.postDetails(req, res, next)
     })
     it('should flash a message to let people know they did something', function (done) {
       const body = {
         id: '1234',
-        name: 'freds'
+        name: 'freds',
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         query: { business_type: 'charity' },
         flash: flashStub,
-        body
+        body,
       }
       const res = {
         locals: {},
@@ -557,7 +557,7 @@ describe('Company controller, uk other', function () {
         },
         render: function () {
           throw Error('error')
-        }
+        },
       }
       companyControllerUkOther.postDetails(req, res, next)
     })
@@ -569,11 +569,11 @@ describe('Company controller, uk other', function () {
     beforeEach(function () {
       req = {
         session: {
-          token: '1234'
-        }
+          token: '1234',
+        },
       }
       res = {
-        locals: {}
+        locals: {},
       }
     })
     it('should include the require properties in the response', function () {

--- a/test/controllers/contact-archive.controller.test.js
+++ b/test/controllers/contact-archive.controller.test.js
@@ -17,11 +17,11 @@ describe('Contact controller, archive', function () {
     contactArchiveController = proxyquire('~/src/controllers/contact-archive.controller', {
       '../repos/contact.repo': {
         archiveContact: contactRepositoryArchiveContactStub,
-        unarchiveContact: contactRepositoryUnArchiveContactStub
+        unarchiveContact: contactRepositoryUnArchiveContactStub,
       },
       'winston': {
-        error: sinon.stub()
-      }
+        error: sinon.stub(),
+      },
     })
     flashStub = sinon.stub()
   })
@@ -30,14 +30,14 @@ describe('Contact controller, archive', function () {
       session: { token },
       body: { archived_reason: 'test', archived_reason_other: '' },
       params: { id },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(token, id, req.body.archived_reason)
         done()
-      }
+      },
     }
 
     contactArchiveController.archiveContact(req, res, next)
@@ -47,14 +47,14 @@ describe('Contact controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: 'otherreason' },
       params: { id },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(contactRepositoryArchiveContactStub).to.be.calledWith(token, id, req.body.archived_reason_other)
         done()
-      }
+      },
     }
 
     contactArchiveController.archiveContact(req, res, next)
@@ -65,14 +65,14 @@ describe('Contact controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: 'otherreason' },
       params: { id },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('success-message', 'Updated contact record')
         done()
-      }
+      },
     }
 
     contactArchiveController.archiveContact(req, res, next)
@@ -82,14 +82,14 @@ describe('Contact controller, archive', function () {
       session: { token },
       body: { archived_reason: 'Other', archived_reason_other: '' },
       params: { id },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function (url) {
         expect(flashStub).to.be.calledWith('error-message', 'Unable to archive contact, no reason given')
         done()
-      }
+      },
     }
 
     contactArchiveController.archiveContact(req, res, next)
@@ -98,14 +98,14 @@ describe('Contact controller, archive', function () {
     const req = {
       session: { token },
       params: { id },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
       locals: {},
       redirect: function () {
         expect(contactRepositoryUnArchiveContactStub).to.be.calledWith(token, id)
         done()
-      }
+      },
     }
 
     contactArchiveController.unarchiveContact(req, res, next)
@@ -116,21 +116,21 @@ describe('Contact controller, archive', function () {
     contactArchiveController = proxyquire('~/src/controllers/contact-archive.controller', {
       '../repos/contact.repo': {
         archiveContact: contactRepositoryArchiveContactStub,
-        unarchiveContact: contactRepositoryUnArchiveContactStub
+        unarchiveContact: contactRepositoryUnArchiveContactStub,
       },
       'winston': {
-        error: sinon.stub()
-      }
+        error: sinon.stub(),
+      },
     })
 
     const req = {
       session: { token },
       params: { id },
       body: { archived_reason: 'test' },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
-      render: function () { throw Error('Should have called next') }
+      render: function () { throw Error('Should have called next') },
     }
     const next = function (_error) {
       expect(_error).to.deep.equal(error)
@@ -145,21 +145,21 @@ describe('Contact controller, archive', function () {
     contactArchiveController = proxyquire('~/src/controllers/contact-archive.controller', {
       '../repos/contact.repo': {
         archiveContact: contactRepositoryArchiveContactStub,
-        unarchiveContact: contactRepositoryUnArchiveContactStub
+        unarchiveContact: contactRepositoryUnArchiveContactStub,
       },
       'winston': {
-        error: sinon.stub()
-      }
+        error: sinon.stub(),
+      },
     })
 
     const req = {
       session: { token },
       params: { id },
       body: { archived_reason: 'test' },
-      flash: flashStub
+      flash: flashStub,
     }
     const res = {
-      render: function () { throw Error('Should have called next') }
+      render: function () { throw Error('Should have called next') },
     }
     const next = function (_error) {
       expect(_error).to.deep.equal(error)

--- a/test/controllers/contact-edit.controller.test.js
+++ b/test/controllers/contact-edit.controller.test.js
@@ -17,7 +17,7 @@ describe('Contact controller, edit', function () {
   beforeEach(function () {
     company = {
       id: '1234',
-      name: 'Fred ltd.'
+      name: 'Fred ltd.',
     }
 
     getDitCompanyStub = sinon.stub().resolves(company)
@@ -27,17 +27,17 @@ describe('Contact controller, edit', function () {
     contactEditController = proxyquire('~/src/controllers/contact-edit.controller', {
       '../services/contact-form.service': {
         getContactAsFormData: getContactAsFormDataStub,
-        saveContactForm: saveContactFormStub
+        saveContactForm: saveContactFormStub,
       },
       '../repos/metadata.repo': {
         countryOptions: [{
           id: '986',
-          name: 'United Kingdom'
-        }]
+          name: 'United Kingdom',
+        }],
       },
       '../repos/company.repo': {
-        getDitCompany: getDitCompanyStub
-      }
+        getDitCompany: getDitCompanyStub,
+      },
     })
   })
 
@@ -80,25 +80,25 @@ describe('Contact controller, edit', function () {
           archived_by: null,
           title: {
             id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-            name: 'Mr'
+            name: 'Mr',
           },
           advisor: null,
           address_country: null,
-          company
+          company,
         }
         req = {
           session: {
-            token: '321'
+            token: '321',
           },
           query: {},
           params: {
-            contactId: '12651151-2149-465e-871b-ac45bc568a62'
-          }
+            contactId: '12651151-2149-465e-871b-ac45bc568a62',
+          },
         }
         res = {
           locals: {
-            contact
-          }
+            contact,
+          },
         }
       })
 
@@ -137,15 +137,15 @@ describe('Contact controller, edit', function () {
       beforeEach(function () {
         req = {
           session: {
-            token: '321'
+            token: '321',
           },
           query: {
-            company: '1234'
+            company: '1234',
           },
-          params: {}
+          params: {},
         }
         res = {
-          locals: {}
+          locals: {},
         }
       })
 
@@ -185,17 +185,17 @@ describe('Contact controller, edit', function () {
           id: '222',
           first_name: 'Fred',
           last_name: 'Smith',
-          company: '1234'
+          company: '1234',
         }
         req = {
           session: {
-            token: '321'
+            token: '321',
           },
           params: {},
           body,
           query: {
-            company: '1234'
-          }
+            company: '1234',
+          },
         }
         res = { locals: {} }
       })
@@ -252,11 +252,11 @@ describe('Contact controller, edit', function () {
           address_country: '123',
           telephone_alternative: '33321',
           email_alternative: 'Fred@gmail.com',
-          notes: 'some notes'
+          notes: 'some notes',
         },
         countryOptions,
         company,
-        contactLabels
+        contactLabels,
       }
     })
     it('should render all the required fields on the page', function () {
@@ -293,21 +293,21 @@ describe('Contact controller, edit', function () {
     beforeEach(function () {
       flashStub = sinon.stub()
       res = {
-        locals: {}
+        locals: {},
       }
       req = {
         session: {
-          token: '321'
+          token: '321',
         },
         params: { id: '1234' },
         query: {},
-        flash: flashStub
+        flash: flashStub,
       }
       body = {
         id: '1234',
         first_name: 'Fred',
         last_name: 'Smith',
-        company: '1234'
+        company: '1234',
       }
       req.body = body
     })
@@ -336,23 +336,23 @@ describe('Contact controller, edit', function () {
     })
     it('should re-render the edit page with the original form data on validation errors', function (done) {
       saveContactFormStub = sinon.stub().rejects({
-        error: { name: ['test'] }
+        error: { name: ['test'] },
       })
 
       contactEditController = proxyquire('~/src/controllers/contact-edit.controller', {
         '../services/contact-form.service': {
           getContactAsFormData: getContactAsFormDataStub,
-          saveContactForm: saveContactFormStub
+          saveContactForm: saveContactFormStub,
         },
         '../repos/metadata.repo': {
           countryOptions: [{
             id: '986',
-            name: 'United Kingdom'
-          }]
+            name: 'United Kingdom',
+          }],
         },
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
-        }
+          getDitCompany: getDitCompanyStub,
+        },
       })
 
       res.render = function (template) {
@@ -368,17 +368,17 @@ describe('Contact controller, edit', function () {
       contactEditController = proxyquire('~/src/controllers/contact-edit.controller', {
         '../services/contact-form.service': {
           getContactAsFormData: getContactAsFormDataStub,
-          saveContactForm: saveContactFormStub
+          saveContactForm: saveContactFormStub,
         },
         '../repos/metadata.repo': {
           countryOptions: [{
             id: '986',
-            name: 'United Kingdom'
-          }]
+            name: 'United Kingdom',
+          }],
         },
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
-        }
+          getDitCompany: getDitCompanyStub,
+        },
       })
 
       contactEditController.postDetails(req, res, function (error) {

--- a/test/controllers/contact-interaction.controller.test.js
+++ b/test/controllers/contact-interaction.controller.test.js
@@ -26,14 +26,14 @@ describe('Contact interactions controller', function () {
     it('should get interactions and service deliveries for a contact', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { contactId: '1' }
+        params: { contactId: '1' },
       }
       const res = {
         locals: { contact },
         render: function () {
           expect(contactDataService.getContactInteractionsAndServiceDeliveries).to.be.calledWith(req.session.token, req.params.contactId)
           done()
-        }
+        },
       }
       contactInteractionController.getInteractions(req, res, next)
     })
@@ -41,14 +41,14 @@ describe('Contact interactions controller', function () {
     it('should format interactions for display', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { contactId: '1' }
+        params: { contactId: '1' },
       }
       const res = {
         locals: { contact },
         render: function (template, options) {
           expect(interactionFormattingService.getDisplayContactInteraction).to.be.calledWith(interaction)
           done()
-        }
+        },
       }
       contactInteractionController.getInteractions(req, res, next)
     })
@@ -56,7 +56,7 @@ describe('Contact interactions controller', function () {
     it('should return a list of interactions', function (done) {
       const req = {
         session: { token: '1234' },
-        params: { contactId: '1' }
+        params: { contactId: '1' },
       }
       const res = {
         locals: { contact },
@@ -64,7 +64,7 @@ describe('Contact interactions controller', function () {
           expect(res.locals).to.have.property('interactions')
           expect(res.locals.interactions).to.have.length(1)
           done()
-        }
+        },
       }
       contactInteractionController.getInteractions(req, res, next)
     })

--- a/test/controllers/contact.controller.test.js
+++ b/test/controllers/contact.controller.test.js
@@ -18,7 +18,7 @@ describe('Contact controller', function () {
     token = '321'
     company = {
       id: '876544',
-      name: 'Bank ltd.'
+      name: 'Bank ltd.',
     }
     companyUrl = '/company/876544'
     contact = {
@@ -49,15 +49,15 @@ describe('Contact controller', function () {
       archived_by: null,
       title: {
         id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-        name: 'Mr'
+        name: 'Mr',
       },
       advisor: null,
       address_country: null,
-      company
+      company,
     }
     contactFormatted = {
       id: '12651151-2149-465e-871b-ac45bc568a62',
-      name: 'fred'
+      name: 'fred',
     }
     getContactStub = sinon.stub().resolves(contact)
     getDisplayContactStub = sinon.stub().returns(contactFormatted)
@@ -65,17 +65,17 @@ describe('Contact controller', function () {
     buildCompanyUrlStub = sinon.stub().returns(companyUrl)
     contactController = proxyquire('~/src/controllers/contact.controller', {
       '../repos/contact.repo': {
-        getContact: getContactStub
+        getContact: getContactStub,
       },
       '../services/contact-formatting.service': {
-        getDisplayContact: getDisplayContactStub
+        getDisplayContact: getDisplayContactStub,
       },
       '../repos/company.repo': {
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
       '../services/company.service': {
-        buildCompanyUrl: buildCompanyUrlStub
-      }
+        buildCompanyUrl: buildCompanyUrlStub,
+      },
     })
   })
 
@@ -84,12 +84,12 @@ describe('Contact controller', function () {
       const req = {
         session: { token },
         params: {
-          contactId: '1234'
-        }
+          contactId: '1234',
+        },
       }
       const res = {
         locals: {},
-        render: function () {}
+        render: function () {},
       }
       const next = function () {
         expect(getContactStub).to.have.been.calledWith(token, req.params.contactId)
@@ -101,14 +101,14 @@ describe('Contact controller', function () {
       const req = {
         session: { token },
         params: {
-          contactId: '1234'
-        }
+          contactId: '1234',
+        },
       }
       const res = {
         locals: {
-          contact
+          contact,
         },
-        render: function () {}
+        render: function () {},
       }
       const next = function () {
         expect(getDitCompanyStub).to.have.been.calledWith(token, contact.company.id)
@@ -121,14 +121,14 @@ describe('Contact controller', function () {
       const req = {
         session: { token },
         params: {
-          contactId: '1234'
-        }
+          contactId: '1234',
+        },
       }
       const res = {
         locals: {
-          company
+          company,
         },
-        render: function () {}
+        render: function () {},
       }
       const next = function () {
         expect(buildCompanyUrlStub).to.have.been.calledWith(company)
@@ -140,12 +140,12 @@ describe('Contact controller', function () {
       const req = {
         session: { token },
         params: {
-          contactId: '1234'
-        }
+          contactId: '1234',
+        },
       }
       const res = {
         locals: {},
-        render: function () {}
+        render: function () {},
       }
       const next = function () {
         expect(res.locals.id).to.equal(req.params.contactId)
@@ -157,28 +157,28 @@ describe('Contact controller', function () {
       const error = Error('error')
       contactController = proxyquire('~/src/controllers/contact.controller', {
         '../repos/contact.repo': {
-          getContact: sinon.stub().rejects(error)
+          getContact: sinon.stub().rejects(error),
         },
         '../services/contact-formatting.service': {
-          getDisplayContact: getDisplayContactStub
+          getDisplayContact: getDisplayContactStub,
         },
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../services/company.service': {
-          buildCompanyUrl: buildCompanyUrlStub
-        }
+          buildCompanyUrl: buildCompanyUrlStub,
+        },
       })
 
       const req = {
         session: { token },
         params: {
-          contactId: '1234'
-        }
+          contactId: '1234',
+        },
       }
       const res = {
         locals: {},
-        render: function () {}
+        render: function () {},
       }
       const next = function (err) {
         expect(err.message).to.equal(error.message)
@@ -193,7 +193,7 @@ describe('Contact controller', function () {
     describe('data', function () {
       it('should include formatted contact data', function (done) {
         const req = {
-          session: {}
+          session: {},
         }
         const res = {
           locals: { contact, id: '1234', company },
@@ -202,7 +202,7 @@ describe('Contact controller', function () {
             expect(res.locals.contactDetails).to.deep.equal(contactFormatted)
             expect(res.locals.contactDetailsLabels).to.deep.equal(contactDetailsLabels)
             done()
-          }
+          },
         }
         contactController.getDetails(req, res, next)
       })
@@ -219,7 +219,7 @@ describe('Contact controller', function () {
           address: '10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
           telephone_alternative: '07814 000 333',
           email_alternative: 'fred@gmail.com',
-          notes: 'some notes'
+          notes: 'some notes',
         }
       })
 

--- a/test/controllers/interaction-edit.controller.test.js
+++ b/test/controllers/interaction-edit.controller.test.js
@@ -22,30 +22,30 @@ describe('Interaction controller, edit', function () {
   beforeEach(function () {
     company = {
       id: '1234',
-      name: 'Fred ltd.'
+      name: 'Fred ltd.',
     }
 
     emailInteractionType = {
       id: '444',
-      name: 'Email'
+      name: 'Email',
     }
 
     const contact = {
       id: '888',
       name: 'Fred Smith',
       first_name: 'Fred',
-      last_name: 'Smith'
+      last_name: 'Smith',
     }
 
     newContactInteraction = {
       contact,
       company,
-      interaction_type: emailInteractionType
+      interaction_type: emailInteractionType,
     }
 
     newCompanyInteraction = {
       company,
-      interaction_type: emailInteractionType
+      interaction_type: emailInteractionType,
     }
 
     getInteractionAsFormDataStub = sinon.stub().returns({ id: '1234', subject: 'Thing', company: '1111', contact: '2222' })
@@ -61,25 +61,25 @@ describe('Interaction controller, edit', function () {
     interactionEditController = proxyquire('~/src/controllers/interaction-edit.controller', {
       '../services/interaction-form.service': {
         getInteractionAsFormData: getInteractionAsFormDataStub,
-        saveInteractionForm: saveInteractionFormStub
+        saveInteractionForm: saveInteractionFormStub,
       },
       '../services/interaction-data.service': {
         createBlankInteractionForCompany: createBlankInteractionForCompanyStub,
         createBlankInteractionForContact: createBlankInteractionForContactStub,
-        getInteractionType: getInteractionTypeStub
+        getInteractionType: getInteractionTypeStub,
       },
       '../repos/contact.repo': {
-        getContactsForCompany: getContactsForCompanyStub
+        getContactsForCompany: getContactsForCompanyStub,
       },
       '../repos/company.repo': {
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
       '../repos/advisor.repo': {
-        getAdvisor: getAdvisorStub
+        getAdvisor: getAdvisorStub,
       },
       '../repos/metadata.repo': {
-        getServiceOffers: getServiceOffersStub
-      }
+        getServiceOffers: getServiceOffersStub,
+      },
     })
   })
 
@@ -95,18 +95,18 @@ describe('Interaction controller, edit', function () {
       beforeEach(function () {
         interaction = {
           id: '1234',
-          subject: 'test'
+          subject: 'test',
         }
         req = {
           session: {
-            token: '1234'
+            token: '1234',
           },
-          query: {}
+          query: {},
         }
         res = {
           locals: {
-            interaction
-          }
+            interaction,
+          },
         }
       })
 
@@ -153,15 +153,15 @@ describe('Interaction controller, edit', function () {
         req = {
           session: {
             token: '1234',
-            user
+            user,
           },
           query: {
             contact: '888',
-            interaction_type: '999'
-          }
+            interaction_type: '999',
+          },
         }
         res = {
-          locals: {}
+          locals: {},
         }
       })
       it('should create a new interaction for a contact if just a contact is passed', function (done) {
@@ -208,15 +208,15 @@ describe('Interaction controller, edit', function () {
         req = {
           session: {
             token: '1234',
-            user
+            user,
           },
           query: {
             company: '888',
-            interaction_type: '999'
-          }
+            interaction_type: '999',
+          },
         }
         res = {
-          locals: {}
+          locals: {},
         }
       })
 
@@ -267,18 +267,18 @@ describe('Interaction controller, edit', function () {
           company: '333',
           contact: '444',
           subject: 'test subject',
-          dit_advisor: '7811'
+          dit_advisor: '7811',
         }
         req = {
           session: {
             token: '1234',
-            user
+            user,
           },
           body,
           query: {
             company: '888',
-            interaction_type: '999'
-          }
+            interaction_type: '999',
+          },
         }
         res = { locals: {} }
       })
@@ -324,14 +324,14 @@ describe('Interaction controller, edit', function () {
           id: '1234',
           name: 'Fred Smith',
           first_name: 'Fred',
-          last_name: 'Smith'
-        }
+          last_name: 'Smith',
+        },
       }
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
-        query: {}
+        query: {},
       }
       const res = {
         locals: { interaction },
@@ -339,7 +339,7 @@ describe('Interaction controller, edit', function () {
           expect(getContactsForCompanyStub).to.be.calledWith(company.id)
           expect(res.locals).to.have.property('contacts')
           done()
-        }
+        },
       }
 
       interactionEditController.editDetails(req, res, next)
@@ -355,17 +355,17 @@ describe('Interaction controller, edit', function () {
           dit_advisor: '7811',
           notes: 'some notes',
           service: '3322',
-          dit_team: '9884'
+          dit_team: '9884',
         },
         company: {
           id: '1234',
-          name: 'Freds'
+          name: 'Freds',
         },
         interaction_type: {
           id: '333',
-          name: 'Email'
+          name: 'Email',
         },
-        labels: interactionLabels
+        labels: interactionLabels,
       }
 
       it('should render all the required fields on the page', function () {
@@ -406,7 +406,7 @@ describe('Interaction controller, edit', function () {
       })
       it('should render errors in a list if there are any', function () {
         locals.errors = {
-          name: ['test']
+          name: ['test'],
         }
         return render(`${__dirname}/../../src/views/interaction/interaction-edit.njk`, locals)
         .then((document) => {
@@ -431,18 +431,18 @@ describe('Interaction controller, edit', function () {
         contact: '444',
         subject: 'test subject',
         dit_advisor: '7811',
-        date: '2017-02-01T00:00:00:00Z'
+        date: '2017-02-01T00:00:00:00Z',
       }
 
       req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
-        body
+        body,
       }
 
       res = {
-        locals: {}
+        locals: {},
       }
     })
 
@@ -464,31 +464,31 @@ describe('Interaction controller, edit', function () {
     })
     it('should re-render the edit page with the original form data on validation errors', function (done) {
       saveInteractionFormStub = sinon.stub().rejects({
-        error: { subject: ['test'] }
+        error: { subject: ['test'] },
       })
 
       interactionEditController = proxyquire('~/src/controllers/interaction-edit.controller', {
         '../services/interaction-form.service': {
           getInteractionAsFormData: getInteractionAsFormDataStub,
-          saveInteractionForm: saveInteractionFormStub
+          saveInteractionForm: saveInteractionFormStub,
         },
         '../services/interaction-data.service': {
           createBlankInteractionForCompany: createBlankInteractionForCompanyStub,
           createBlankInteractionForContact: createBlankInteractionForContactStub,
-          getInteractionType: getInteractionTypeStub
+          getInteractionType: getInteractionTypeStub,
         },
         '../repos/contact.repo': {
-          getContactsForCompany: getContactsForCompanyStub
+          getContactsForCompany: getContactsForCompanyStub,
         },
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/advisor.repo': {
-          getAdvisor: getAdvisorStub
+          getAdvisor: getAdvisorStub,
         },
         '../repos/metadata.repo': {
-          getServiceOffers: getServiceOffersStub
-        }
+          getServiceOffers: getServiceOffersStub,
+        },
       })
 
       res.render = function (url) {
@@ -502,25 +502,25 @@ describe('Interaction controller, edit', function () {
       interactionEditController = proxyquire('~/src/controllers/interaction-edit.controller', {
         '../services/interaction-form.service': {
           getInteractionAsFormData: getInteractionAsFormDataStub,
-          saveInteractionForm: saveInteractionFormStub
+          saveInteractionForm: saveInteractionFormStub,
         },
         '../services/interaction-data.service': {
           createBlankInteractionForCompany: createBlankInteractionForCompanyStub,
           createBlankInteractionForContact: createBlankInteractionForContactStub,
-          getInteractionType: getInteractionTypeStub
+          getInteractionType: getInteractionTypeStub,
         },
         '../repos/contact.repo': {
-          getContactsForCompany: getContactsForCompanyStub
+          getContactsForCompany: getContactsForCompanyStub,
         },
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/advisor.repo': {
-          getAdvisor: getAdvisorStub
+          getAdvisor: getAdvisorStub,
         },
         '../repos/metadata.repo': {
-          getServiceOffers: getServiceOffersStub
-        }
+          getServiceOffers: getServiceOffersStub,
+        },
       })
 
       interactionEditController.postDetails(req, res, function (error) {

--- a/test/controllers/investment-create.controller.test.js
+++ b/test/controllers/investment-create.controller.test.js
@@ -5,12 +5,12 @@ const company = {
   contacts: [{
     id: 1,
     first_name: 'Bob',
-    last_name: 'Stevens'
-  }]
+    last_name: 'Stevens',
+  }],
 }
 const investmentProjects = {
   count: 0,
-  results: []
+  results: [],
 }
 const investmentProjectSummary = {
   id: '12345',
@@ -25,8 +25,8 @@ const advisorMock = {
       id: 1,
       first_name: 'Jeff',
       last_name: 'Major',
-    }
-  ]
+    },
+  ],
 }
 
 describe('Investment create controller', () => {
@@ -44,20 +44,20 @@ describe('Investment create controller', () => {
 
     this.controller = proxyquire('~/src/controllers/investment-create.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: this.getInflatedDitCompany
+        getInflatedDitCompany: this.getInflatedDitCompany,
       },
       '../repos/investment.repo': {
         getCompanyInvestmentProjects: this.getCompanyInvestmentProjects,
         getInvestmentProjectSummary: this.getInvestmentProjectSummary,
         createInvestmentProject: this.createInvestmentProject,
-        updateInvestmentProject: this.updateInvestmentProject
+        updateInvestmentProject: this.updateInvestmentProject,
       },
       '../services/investment-formatting.service': {
         transformToApi: this.transformToApi,
-        transformFromApi: this.transformFromApi
+        transformFromApi: this.transformFromApi,
       },
       '../repos/advisor.repo': {
-        getAdvisors: this.getAdvisors
+        getAdvisors: this.getAdvisors,
       },
       '../repos/metadata.repo': {
         investmentTypeOptions: [{ id: 1, name: 'FDI' }],
@@ -67,8 +67,8 @@ describe('Investment create controller', () => {
         referralSourceMarketingOptions: [{ name: 'Marketing' }],
         referralSourceWebsiteOptions: [{ name: 'Website' }],
         businessActivityOptions: [],
-        sectorOptions: []
-      }
+        sectorOptions: [],
+      },
     })
   })
 
@@ -81,15 +81,15 @@ describe('Investment create controller', () => {
       it('should redirect to the start', (done) => {
         this.controller.getHandler({
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
-          query: {}
+          query: {},
         }, {
           redirect: (url) => {
             expect(url).to.equal('/investment/start')
             done()
           },
-          locals: {}
+          locals: {},
         }, this.next)
       })
     })
@@ -98,11 +98,11 @@ describe('Investment create controller', () => {
       it('should render company details', (done) => {
         this.controller.getHandler({
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
           query: {
-            'equity-company': '12345'
-          }
+            'equity-company': '12345',
+          },
         }, {
           locals: {},
           render: (template, data) => {
@@ -128,15 +128,15 @@ describe('Investment create controller', () => {
                   referralSourceMarketing: [{ name: 'Marketing' }],
                   referralSourceWebsite: [{ name: 'Website' }],
                   businessActivities: [],
-                  primarySectors: []
-                }
+                  primarySectors: [],
+                },
               })
 
               done()
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -146,16 +146,16 @@ describe('Investment create controller', () => {
     describe('when save is resolved with an object', () => {
       beforeEach(() => {
         this.createInvestmentProject = this.createInvestmentProject.resolves({
-          id: '12345'
+          id: '12345',
         })
       })
 
       it('should redirect to the investment project', (done) => {
         this.controller.postHandler({
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
-          body: {}
+          body: {},
         }, {
           redirect: (url) => {
             try {
@@ -167,7 +167,7 @@ describe('Investment create controller', () => {
               done(e)
             }
           },
-          locals: {}
+          locals: {},
         }, this.next)
       })
     })
@@ -175,19 +175,19 @@ describe('Investment create controller', () => {
     describe('when project id is set', () => {
       beforeEach(() => {
         this.updateInvestmentProject = this.updateInvestmentProject.resolves({
-          id: '5678'
+          id: '5678',
         })
       })
 
       it('should call the edit method', (done) => {
         this.controller.postHandler({
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
-          body: {}
+          body: {},
         }, {
           locals: {
-            projectId: '5678'
+            projectId: '5678',
           },
           redirect: (url) => {
             try {
@@ -198,7 +198,7 @@ describe('Investment create controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -208,19 +208,19 @@ describe('Investment create controller', () => {
         this.createInvestmentProject = this.createInvestmentProject.rejects({
           statusCode: 400,
           error: {
-            foo: 'field must not be empty'
-          }
+            foo: 'field must not be empty',
+          },
         })
       })
 
       it('should set the error to locals and continue', (done) => {
         const req = {
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
           body: {
-            foo: 'bar'
-          }
+            foo: 'bar',
+          },
         }
         const res = { locals: {} }
         const next = function () {
@@ -228,12 +228,12 @@ describe('Investment create controller', () => {
             expect(res.locals).to.deep.equal({
               form: {
                 errors: {
-                  foo: 'field must not be empty'
+                  foo: 'field must not be empty',
                 },
                 state: {
-                  foo: 'bar'
-                }
-              }
+                  foo: 'bar',
+                },
+              },
             })
             done()
           } catch (e) {
@@ -274,12 +274,12 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
             user: {
-              id: '1a2b3c4d5e'
-            }
+              id: '1a2b3c4d5e',
+            },
           },
           params: {
-            id: '12345'
-          }
+            id: '12345',
+          },
         }
         const res = { locals: {} }
         const next = function () {
@@ -296,8 +296,8 @@ describe('Investment create controller', () => {
                   referral_source_advisor: '333444',
                   'is-relationship-manager': 'No',
                   'is-referral-source': 'No',
-                }
-              }
+                },
+              },
             })
             done()
           } catch (e) {
@@ -328,12 +328,12 @@ describe('Investment create controller', () => {
           session: {
             token: 'abcd',
             user: {
-              id: '1a2b3c4d5e'
-            }
+              id: '1a2b3c4d5e',
+            },
           },
           params: {
-            id: '12345'
-          }
+            id: '12345',
+          },
         }
         const res = { locals: {} }
         const next = function () {
@@ -350,8 +350,8 @@ describe('Investment create controller', () => {
                   referral_source_advisor: '1a2b3c4d5e',
                   'is-relationship-manager': '1a2b3c4d5e',
                   'is-referral-source': '1a2b3c4d5e',
-                }
-              }
+                },
+              },
             })
             done()
           } catch (e) {
@@ -371,11 +371,11 @@ describe('Investment create controller', () => {
       it('should set the error to locals and continue', (done) => {
         const req = {
           session: {
-            token: 'abcd'
+            token: 'abcd',
           },
           params: {
-            id: '12345'
-          }
+            id: '12345',
+          },
         }
         const res = {}
         const next = function (err) {

--- a/test/controllers/investment-details.controller.test.js
+++ b/test/controllers/investment-details.controller.test.js
@@ -16,8 +16,8 @@ describe('Investment details controller', () => {
       '../repos/investment.repo': {
         getInvestmentProjectSummary: this.getInvestmentProjectSummary,
         getInvestmentValue: this.getInvestmentValue,
-        getInvestmentRequirements: this.getInvestmentRequirements
-      }
+        getInvestmentRequirements: this.getInvestmentRequirements,
+      },
     })
   })
 
@@ -36,14 +36,14 @@ describe('Investment details controller', () => {
           { label: 'Interactions', slug: 'interactions' },
           { label: 'Documents', slug: 'documents' },
           { label: 'Evaluation', slug: 'evaluation' },
-          { label: 'Audit history', slug: 'audit' }
+          { label: 'Audit history', slug: 'audit' },
         ],
         project: {
           'Anonymous description': null,
           'Business activity': undefined,
           'Client': {
             name: 'Wonka Industries',
-            url: '/company/view/foreign/6c388e5b-a098-e211-a939-e4115bead28a'
+            url: '/company/view/foreign/6c388e5b-a098-e211-a939-e4115bead28a',
           },
           'Estimated land date': 'May 2018',
           'Non-disclosure agreement': 'Not signed',
@@ -51,13 +51,13 @@ describe('Investment details controller', () => {
           'Project description': 'Stark Industries wishes to build in a new part of Manchester expanding its existing premises',
           'Shareable with UK partners': null,
           'Sub-sector': null,
-          'Type of investment': 'Commitment to invest'
+          'Type of investment': 'Commitment to invest',
         },
         projectMeta: {
           id: 'f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7',
           name: 'Skyscraper project for Stark Industries',
           phaseName: 'Prospect',
-          projectCode: 'DHP-00000003'
+          projectCode: 'DHP-00000003',
         },
         requirements: {
           'Client requirements': null,
@@ -65,7 +65,7 @@ describe('Investment details controller', () => {
           'Investment location': null,
           'Main strategic drivers': [],
           'Possible UK locations': [],
-          'UK recipient company': null
+          'UK recipient company': null,
         },
         value: {
           'Average salary': null,
@@ -77,17 +77,17 @@ describe('Investment details controller', () => {
           'Non-FDI R&D project': null,
           'R&D budget': null,
           'Safeguarded jobs': null,
-          'Total investment': null
-        }
+          'Total investment': null,
+        },
       }
 
       this.controller.getDetails({
         session: {
-          token
+          token,
         },
         params: {
-          id: investmentProjectSummaryData.id
-        }
+          id: investmentProjectSummaryData.id,
+        },
       }, {
         render: (template, data) => {
           try {
@@ -102,7 +102,7 @@ describe('Investment details controller', () => {
           } catch (error) {
             done(error)
           }
-        }
+        },
       }, this.next)
     })
   })

--- a/test/controllers/investment-start.controller.test.js
+++ b/test/controllers/investment-start.controller.test.js
@@ -2,20 +2,20 @@ const token = 'abcd'
 const ukCompany = {
   id: '12345',
   name: 'Test company',
-  uk_based: true
+  uk_based: true,
 }
 const foreignCompany = {
   id: '12345',
   name: 'Test company',
-  uk_based: false
+  uk_based: false,
 }
 const investmentProjects = {
   count: 0,
-  results: []
+  results: [],
 }
 const searchResults = {
   count: 0,
-  hits: []
+  hits: [],
 }
 
 describe('Investment start controller', () => {
@@ -29,17 +29,17 @@ describe('Investment start controller', () => {
 
     this.controller = proxyquire('~/src/controllers/investment-start.controller', {
       '../services/company.service': {
-        getInflatedDitCompany: this.getInflatedDitCompany
+        getInflatedDitCompany: this.getInflatedDitCompany,
       },
       '../repos/investment.repo': {
-        getCompanyInvestmentProjects: this.getCompanyInvestmentProjects
+        getCompanyInvestmentProjects: this.getCompanyInvestmentProjects,
       },
       '../services/search.service': {
-        search: this.search
+        search: this.search,
       },
       '../lib/pagination': {
-        getPagination: this.getPagination
-      }
+        getPagination: this.getPagination,
+      },
     })
   })
 
@@ -52,9 +52,9 @@ describe('Investment start controller', () => {
       it('should render company details and search', (done) => {
         this.controller.getHandler({
           session: {
-            token
+            token,
           },
-          query: {}
+          query: {},
         }, {
           render: (template, data) => {
             try {
@@ -65,7 +65,7 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -74,11 +74,11 @@ describe('Investment start controller', () => {
       it('should render company details and search', (done) => {
         this.controller.getHandler({
           session: {
-            token
+            token,
           },
           query: {
-            'client-company': '12345'
-          }
+            'client-company': '12345',
+          },
         }, {
           render: (template, data) => {
             try {
@@ -92,7 +92,7 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -105,11 +105,11 @@ describe('Investment start controller', () => {
       it('should render company details and no search', (done) => {
         this.controller.getHandler({
           session: {
-            token
+            token,
           },
           query: {
-            'client-company': '12345'
-          }
+            'client-company': '12345',
+          },
         }, {
           render: (template, data) => {
             try {
@@ -123,19 +123,19 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
 
       it('should render search', (done) => {
         this.controller.getHandler({
           session: {
-            token
+            token,
           },
           query: {
             'client-company': '12345',
-            'show-search': true
-          }
+            'show-search': true,
+          },
         }, {
           render: (template, data) => {
             try {
@@ -144,7 +144,7 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -153,12 +153,12 @@ describe('Investment start controller', () => {
       it('should render results', (done) => {
         this.controller.getHandler({
           session: {
-            token
+            token,
           },
           query: {
             'client-company': '12345',
-            'q': 'samsung'
-          }
+            'q': 'samsung',
+          },
         }, {
           render: (template, data) => {
             try {
@@ -169,7 +169,7 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })
@@ -181,13 +181,13 @@ describe('Investment start controller', () => {
         this.controller.postHandler({
           body: {
             'client-company': '12345',
-            'is-equity-source': 'true'
-          }
+            'is-equity-source': 'true',
+          },
         }, {
           redirect: (path) => {
             expect(path).to.equal('/investment/create?equity-company=12345')
             done()
-          }
+          },
         }, this.next)
       })
     })
@@ -197,13 +197,13 @@ describe('Investment start controller', () => {
         this.controller.postHandler({
           body: {
             'client-company': '12345',
-            'is-equity-source': 'false'
-          }
+            'is-equity-source': 'false',
+          },
         }, {
           redirect: (path) => {
             expect(path).to.equal('/investment/start?client-company=12345&show-search=true')
             done()
-          }
+          },
         }, this.next)
       })
     })
@@ -212,11 +212,11 @@ describe('Investment start controller', () => {
       it('should redirect to the create step', (done) => {
         this.controller.postHandler({
           session: {
-            token
+            token,
           },
           body: {
-            'client-company': '12345'
-          }
+            'client-company': '12345',
+          },
         }, {
           render: (template, data) => {
             try {
@@ -226,7 +226,7 @@ describe('Investment start controller', () => {
             } catch (e) {
               done(e)
             }
-          }
+          },
         }, this.next)
       })
     })

--- a/test/controllers/search.controller.test.js
+++ b/test/controllers/search.controller.test.js
@@ -15,25 +15,25 @@ describe('Search controller', function () {
             uk_based: true,
             business_type: {
               id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-              name: 'Private limited company'
-            }
-          })
-        }
+              name: 'Private limited company',
+            },
+          }),
+        },
       })
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }
       const res = {
         locals: {},
         redirect: function (url) {
           expect(url).to.equal('/company/view/ltd/9999')
           done()
-        }
+        },
       }
       searchController.viewCompanyResult(req, res, next)
     })
@@ -45,25 +45,25 @@ describe('Search controller', function () {
             uk_based: true,
             business_type: {
               id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-              name: 'Public limited company'
-            }
-          })
-        }
+              name: 'Public limited company',
+            },
+          }),
+        },
       })
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }
       const res = {
         locals: {},
         redirect: function (url) {
           expect(url).to.equal('/company/view/ltd/9999')
           done()
-        }
+        },
       }
       searchController.viewCompanyResult(req, res, next)
     })
@@ -75,25 +75,25 @@ describe('Search controller', function () {
             uk_based: true,
             business_type: {
               id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-              name: 'Partnership'
-            }
-          })
-        }
+              name: 'Partnership',
+            },
+          }),
+        },
       })
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }
       const res = {
         locals: {},
         redirect: function (url) {
           expect(url).to.equal('/company/view/ukother/9999')
           done()
-        }
+        },
       }
       searchController.viewCompanyResult(req, res, next)
     })
@@ -105,25 +105,25 @@ describe('Search controller', function () {
             uk_based: false,
             business_type: {
               id: '9bd14e94-5d95-e211-a939-e4115bead28a',
-              name: 'Company'
-            }
-          })
-        }
+              name: 'Company',
+            },
+          }),
+        },
       })
       const req = {
         session: {
-          token: '1234'
+          token: '1234',
         },
         params: {
-          id: '9999'
-        }
+          id: '9999',
+        },
       }
       const res = {
         locals: {},
         redirect: function (url) {
           expect(url).to.equal('/company/view/foreign/9999')
           done()
-        }
+        },
       }
       searchController.viewCompanyResult(req, res, next)
     })
@@ -147,15 +147,15 @@ describe('Search Controller', () => {
         this.controller.indexAction(
           {
             session: {
-              token: '1234'
+              token: '1234',
             },
-            query: {}
+            query: {},
           },
           {
             render: (template) => {
               expect(template).to.equal('search/index')
               done()
-            }
+            },
           }, this.next
         )
       })
@@ -166,11 +166,11 @@ describe('Search Controller', () => {
         this.controller.indexAction(
           {
             session: {
-              token: '1234'
+              token: '1234',
             },
             query: {
-              term: 'mock term'
-            }
+              term: 'mock term',
+            },
           }, {}, this.next
         )
 
@@ -185,13 +185,13 @@ describe('Search Controller', () => {
       {
         count: 3,
         entity: 'company',
-        text: 'Companies'
+        text: 'Companies',
       },
       {
         count: 1,
         entity: 'contact',
-        text: 'Contacts'
-      }
+        text: 'Contacts',
+      },
     ]
 
     describe('when called with "company" searchType', () => {
@@ -201,7 +201,7 @@ describe('Search Controller', () => {
         const token = '1234'
         const searchType = 'company'
         const expectedResults = Object.assign({}, companyResponse, {
-          page: 1
+          page: 1,
         })
 
         nock(config.apiRoot)
@@ -210,21 +210,21 @@ describe('Search Controller', () => {
             term: searchTerm,
             entity: searchType,
             limit: 10,
-            offset: 0
+            offset: 0,
           })
           .reply(200, companyResponse)
 
         this.controller.searchAction(
           {
             session: {
-              token
+              token,
             },
             query: {
-              term: searchTerm
+              term: searchTerm,
             },
             params: {
-              searchType
-            }
+              searchType,
+            },
           },
           {
             render: (template, data) => {
@@ -240,7 +240,7 @@ describe('Search Controller', () => {
               } catch (e) {
                 done(e)
               }
-            }
+            },
           }, this.next
         )
       })
@@ -252,7 +252,7 @@ describe('Search Controller', () => {
       it('should render results page for contact', (done) => {
         const searchType = 'contact'
         const expectedResults = Object.assign({}, contactResponse, {
-          page: 1
+          page: 1,
         })
 
         nock(config.apiRoot)
@@ -261,21 +261,21 @@ describe('Search Controller', () => {
             term: searchTerm,
             entity: searchType,
             limit: 10,
-            offset: 0
+            offset: 0,
           })
           .reply(200, contactResponse)
 
         this.controller.searchAction(
           {
             session: {
-              token: '1234'
+              token: '1234',
             },
             query: {
-              term: searchTerm
+              term: searchTerm,
             },
             params: {
-              searchType
-            }
+              searchType,
+            },
           },
           {
             render: (template, data) => {
@@ -291,7 +291,7 @@ describe('Search Controller', () => {
               } catch (e) {
                 done(e)
               }
-            }
+            },
           }, this.next
         )
       })

--- a/test/data/formatted-contact-interaction.js
+++ b/test/data/formatted-contact-interaction.js
@@ -7,5 +7,5 @@ module.exports = {
   advisor: 'John Brown',
   service: 'service name',
   notes: 'Here are some notes<br/>line 2.',
-  dit_team: 'team name'
+  dit_team: 'team name',
 }

--- a/test/data/simple-contact.js
+++ b/test/data/simple-contact.js
@@ -26,12 +26,12 @@ module.exports = {
   archived_by: null,
   title: {
     id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-    name: 'Mr'
+    name: 'Mr',
   },
   advisor: null,
   address_country: null,
   company: {
     id: '555',
-    name: 'Fred ltd'
-  }
+    name: 'Fred ltd',
+  },
 }

--- a/test/data/simple-interaction.js
+++ b/test/data/simple-interaction.js
@@ -3,5 +3,5 @@ module.exports = {
   interaction_type: { id: '1234', name: 'Email' },
   subject: 'Subject 1234',
   date: '2017-02-14T14:49:17',
-  dit_advisor: { first_name: 'Fred', last_name: 'Smith' }
+  dit_advisor: { first_name: 'Fred', last_name: 'Smith' },
 }

--- a/test/form-helpers.js
+++ b/test/form-helpers.js
@@ -78,5 +78,5 @@ module.exports = {
   expectDateFieldWithLabel,
   expectDropdownWithLabel,
   expectRadioWithLabel,
-  expectHiddenField
+  expectHiddenField,
 }

--- a/test/javascripts/add-another-field.test.js
+++ b/test/javascripts/add-another-field.test.js
@@ -28,9 +28,9 @@ describe('Add another field', function () {
     addAnotherField = new AddAnotherField(wrapper)
     event = {
       target: {
-        blur: sinon.stub()
+        blur: sinon.stub(),
       },
-      preventDefault: sinon.stub()
+      preventDefault: sinon.stub(),
     }
   })
 

--- a/test/javascripts/archive-form.test.js
+++ b/test/javascripts/archive-form.test.js
@@ -30,7 +30,7 @@ const HTML = `
   </div>
 `
 const event = {
-  preventDefault: function () {}
+  preventDefault: function () {},
 }
 
 function domTokenToArray (obj) {

--- a/test/javascripts/sectors.test.js
+++ b/test/javascripts/sectors.test.js
@@ -69,8 +69,8 @@ describe('Sector control', function () {
       it('should show a dropdown of sub sectors if the chosen sector has sub sectors', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
 
         const subsectorSelectElement = document.querySelector('.subsector-wrapper select')
@@ -87,8 +87,8 @@ describe('Sector control', function () {
       it('should not show a dropdown for sub sectors if selected sector has no sub sectors', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Advanced Engineering'
-          }
+            value: 'Advanced Engineering',
+          },
         })
 
         const subsectorSelectElement = document.querySelector('.subsector-wrapper select')
@@ -97,13 +97,13 @@ describe('Sector control', function () {
       it('should hide the sub sector dropdown if you select a sector with sub sectors and then select one that doesnt have sub sectors', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Advanced Engineering'
-          }
+            value: 'Advanced Engineering',
+          },
         })
 
         const subsectorSelectElement = document.querySelector('.subsector-wrapper select')
@@ -114,8 +114,8 @@ describe('Sector control', function () {
       it('should not store a value if you select a primary sector that has sub sectors', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(0)
       })
@@ -123,29 +123,29 @@ describe('Sector control', function () {
         sectorsControl.sourceSelect.selectedIndex = 1
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(0)
       })
       it('should set the original select if you select a sector that has no sub sectors', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Advanced Engineering'
-          }
+            value: 'Advanced Engineering',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(1)
       })
       it('should set the original select if you select a primary sector and then a sub sector', function () {
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         sectorsControl.handleSubsectorSelect({
           target: {
-            value: 'e9e181d2-f6a0-e211-b972-e4115bead28a'
-          }
+            value: 'e9e181d2-f6a0-e211-b972-e4115bead28a',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(2)
       })
@@ -227,8 +227,8 @@ describe('Sector control', function () {
         const sectorsControl = new Sectors(document.getElementById('sector-wrapper'), document)
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Advanced Engineering'
-          }
+            value: 'Advanced Engineering',
+          },
         })
 
         const subsectorSelectElement = document.querySelector('.subsector-wrapper select')
@@ -241,8 +241,8 @@ describe('Sector control', function () {
         document = window.document
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(0)
       })
@@ -251,8 +251,8 @@ describe('Sector control', function () {
         document = window.document
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Advanced Engineering'
-          }
+            value: 'Advanced Engineering',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(1)
       })
@@ -261,13 +261,13 @@ describe('Sector control', function () {
         document = window.document
         sectorsControl.handlePrimarySelect({
           target: {
-            value: 'Aerospace'
-          }
+            value: 'Aerospace',
+          },
         })
         sectorsControl.handleSubsectorSelect({
           target: {
-            value: 'e9e181d2-f6a0-e211-b972-e4115bead28a'
-          }
+            value: 'e9e181d2-f6a0-e211-b972-e4115bead28a',
+          },
         })
         expect(sectorsControl.sourceSelect.selectedIndex).to.eq(2)
       })

--- a/test/lib/address.test.js
+++ b/test/lib/address.test.js
@@ -12,9 +12,9 @@ describe('Address formatter', function () {
       address_county: 'Large County',
       address_country: {
         id: '1234',
-        name: 'Country'
+        name: 'Country',
       },
-      address_postcode: 'LL1 1LL'
+      address_postcode: 'LL1 1LL',
     }
     const actual = address.getFormattedAddress(source)
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, Country')
@@ -28,7 +28,7 @@ describe('Address formatter', function () {
       address_4: '',
       address_town: 'Big Town',
       address_county: 'Large County',
-      address_postcode: 'LL1 1LL'
+      address_postcode: 'LL1 1LL',
     }
     const actual = address.getFormattedAddress(source)
     expect(actual).equal('10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom')
@@ -42,7 +42,7 @@ describe('Address formatter', function () {
       trading_address_4: '',
       trading_address_town: 'Big Town',
       trading_address_county: 'Large County',
-      trading_address_postcode: 'LL1 1LL'
+      trading_address_postcode: 'LL1 1LL',
     }
 
     const actual = address.getFormattedAddress(source, 'trading')
@@ -57,7 +57,7 @@ describe('Address formatter', function () {
       address_4: '',
       address_town: '',
       address_county: '',
-      address_postcode: ''
+      address_postcode: '',
     }
     const actual = address.getFormattedAddress(source)
     expect(actual).to.be.null

--- a/test/lib/controller-utils.test.js
+++ b/test/lib/controller-utils.test.js
@@ -29,9 +29,9 @@ describe('transformV2Errors: Formatting V2 service delivery endpoint errors', fu
       {
         'detail': 'This combination of service and service provider does not exist.',
         'source': {
-          'pointer': '/data/relationships/service'
-        }
-      }
+          'pointer': '/data/relationships/service',
+        },
+      },
     ]
     const actual = transformV2Errors(source)
     expect(actual.Alert).to.exist
@@ -42,57 +42,57 @@ describe('transformV2Errors: Formatting V2 service delivery endpoint errors', fu
       {
         'detail': 'Required',
         'source': {
-          'pointer': '/data/attributes/subject'
-        }
+          'pointer': '/data/attributes/subject',
+        },
       },
       {
         'detail': 'Required',
         'source': {
-          'pointer': '/data/attributes/notes'
-        }
+          'pointer': '/data/attributes/notes',
+        },
       },
       {
         'detail': "{'data': {'type': 'ServiceDeliveryStatus'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/status'
-        }
+          'pointer': '/data/relationships/status',
+        },
       },
       {
         'detail': "{'data': {'type': 'Contact'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/contact'
-        }
+          'pointer': '/data/relationships/contact',
+        },
       },
       {
         'detail': "{'data': {'type': 'Service'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/service'
-        }
+          'pointer': '/data/relationships/service',
+        },
       },
       {
         'detail': "{'data': {'type': 'Team'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/dit_team'
-        }
+          'pointer': '/data/relationships/dit_team',
+        },
       },
       {
         'detail': "{'data': {'type': 'Sector'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/sector'
-        }
+          'pointer': '/data/relationships/sector',
+        },
       },
       {
         'detail': "{'data': {'type': 'UKRegion'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/uk_region'
-        }
+          'pointer': '/data/relationships/uk_region',
+        },
       },
       {
         'detail': "{'data': {'type': 'Country'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/country_of_interest'
-        }
-      }
+          'pointer': '/data/relationships/country_of_interest',
+        },
+      },
     ]
     const actual = transformV2Errors(source)
     expect((Object.keys(actual)).length).to.equal(9)
@@ -111,9 +111,9 @@ describe('transformV2Errors: Formatting V2 service delivery endpoint errors', fu
       {
         'detail': "{'data': {'type': 'Foo'}} has no key id",
         'source': {
-          'pointer': '/data/relationships/foo'
-        }
-      }
+          'pointer': '/data/relationships/foo',
+        },
+      },
     ]
     const actual = transformV2Errors(source)
     expect(actual.foo).to.be.defined

--- a/test/lib/pagination.test.js
+++ b/test/lib/pagination.test.js
@@ -1,6 +1,6 @@
 const pagination = require('~/src/lib/pagination')
 const result = {
-  count: 0
+  count: 0,
 }
 
 describe('Pagination', () => {
@@ -8,8 +8,8 @@ describe('Pagination', () => {
     it('should show 1..5 when on the first pages of many', () => {
       const req = {
         query: {
-          page: '1'
-        }
+          page: '1',
+        },
       }
 
       result.count = 1000
@@ -24,8 +24,8 @@ describe('Pagination', () => {
     it('should show 1..5 when on the second pages of many', () => {
       const req = {
         query: {
-          page: '2'
-        }
+          page: '2',
+        },
       }
 
       result.count = 1000
@@ -39,8 +39,8 @@ describe('Pagination', () => {
     it('should show 3..7 when on the fifth pages of many', () => {
       const req = {
         query: {
-          page: '5'
-        }
+          page: '5',
+        },
       }
 
       result.count = 1000
@@ -54,8 +54,8 @@ describe('Pagination', () => {
     it('should show 10..14 when on pages 13 of 14', () => {
       const req = {
         query: {
-          page: '13'
-        }
+          page: '13',
+        },
       }
 
       result.count = 140
@@ -69,8 +69,8 @@ describe('Pagination', () => {
     it('should show 1..3 when on the first pages of 25 results', () => {
       const req = {
         query: {
-          page: '1'
-        }
+          page: '1',
+        },
       }
 
       result.count = 25
@@ -84,8 +84,8 @@ describe('Pagination', () => {
     it('should show 1..3 when on the second pages of 25 results', () => {
       const req = {
         query: {
-          page: '2'
-        }
+          page: '2',
+        },
       }
 
       result.count = 25
@@ -99,8 +99,8 @@ describe('Pagination', () => {
     it('should not have a next link when on the last pages', () => {
       const req = {
         query: {
-          page: '3'
-        }
+          page: '3',
+        },
       }
 
       result.count = 25
@@ -110,7 +110,7 @@ describe('Pagination', () => {
     })
     it('should show 1..5 when many results and no page number in url', () => {
       const req = {
-        query: {}
+        query: {},
       }
 
       result.count = 1000

--- a/test/lib/property-helpers.test.js
+++ b/test/lib/property-helpers.test.js
@@ -4,7 +4,7 @@ describe('PropertyHelpers: Conversion of empty values to nulls in an object with
   it('Should convert an empty string to a null', function () {
     const source = {
       foo: 'foo',
-      bar: ''
+      bar: '',
     }
     const actual = propertyHelpers.nullEmptyFields(source)
     expect(actual.foo).equal('foo')
@@ -13,7 +13,7 @@ describe('PropertyHelpers: Conversion of empty values to nulls in an object with
   it('Should leave existing nulls alone', function () {
     const source = {
       foo: 'foo',
-      bar: null
+      bar: null,
     }
     const actual = propertyHelpers.nullEmptyFields(source)
     expect(actual.foo).equal('foo')
@@ -25,7 +25,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
   it('Removes fields that have null values from an object', function () {
     const source = {
       foo: 'foo',
-      bar: null
+      bar: null,
     }
     const actual = propertyHelpers.deleteNulls(source)
     expect(actual.foo).equal('foo')
@@ -34,7 +34,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
   it('Return an empty object if all fields are null', function () {
     const source = {
       foo: null,
-      bar: null
+      bar: null,
     }
     const actual = propertyHelpers.deleteNulls(source)
     expect(actual).to.deep.equal({})
@@ -42,7 +42,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
   it('Should ignore empty strings', function () {
     const source = {
       foo: 'foo',
-      bar: ''
+      bar: '',
     }
     const actual = propertyHelpers.deleteNulls(source)
     expect(actual.foo).to.equal('foo')
@@ -51,7 +51,7 @@ describe('PropertyHelpers: Stripping fields with null values out of an object wi
   it('Should ignore false fields', function () {
     const source = {
       foo: 'foo',
-      bar: false
+      bar: false,
     }
     const actual = propertyHelpers.deleteNulls(source)
     expect(actual.foo).to.equal('foo')
@@ -65,8 +65,8 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
       foo: 'bar',
       data: {
         id: '123456',
-        name: 'morph the cat'
-      }
+        name: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyName(source, 'data')
     expect(actual).to.equal('morph the cat')
@@ -76,8 +76,8 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
       foo: 'bar',
       data: {
         id: '123456',
-        nomme: 'morph the cat'
-      }
+        nomme: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyName(source, 'data')
     expect(actual).to.eq(null)
@@ -87,8 +87,8 @@ describe('PropertyHelpers: Finding names in objects with getPropertyName', funct
       foo: 'bar',
       picard: {
         id: '123456',
-        nomme: 'morph the cat'
-      }
+        nomme: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyName(source, 'data')
     expect(actual).to.be.null
@@ -101,8 +101,8 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
       foo: 'bar',
       data: {
         id: '123456',
-        name: 'morph the cat'
-      }
+        name: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyId(source, 'data')
     expect(actual).to.equal('123456')
@@ -112,8 +112,8 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
       foo: 'bar',
       data: {
         guid: '123456',
-        name: 'morph the cat'
-      }
+        name: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyId(source, 'data')
     expect(actual).to.equal(null)
@@ -123,8 +123,8 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
       foo: 'bar',
       picard: {
         id: '123456',
-        nomme: 'morph the cat'
-      }
+        nomme: 'morph the cat',
+      },
     }
     const actual = propertyHelpers.getPropertyId(source, 'data')
     expect(actual).to.be.null
@@ -134,7 +134,7 @@ describe('PropertyHelpers: Finding IDs in objects with getPropertyId', function 
 describe('PropertyHelpers: Convert Yes and No string to true and false with convertYesNoToBoolean', function () {
   it('Should turn a Yes into a boolean true', function () {
     const source = {
-      foo: 'Yes'
+      foo: 'Yes',
     }
 
     const actual = propertyHelpers.convertYesNoToBoolean(source)
@@ -143,7 +143,7 @@ describe('PropertyHelpers: Convert Yes and No string to true and false with conv
   })
   it('Should turn a No into a boolean false', function () {
     const source = {
-      foo: 'No'
+      foo: 'No',
     }
 
     const actual = propertyHelpers.convertYesNoToBoolean(source)
@@ -153,7 +153,7 @@ describe('PropertyHelpers: Convert Yes and No string to true and false with conv
   it('Should ignore case', function () {
     const source = {
       foo: 'yES',
-      bar: 'nO'
+      bar: 'nO',
     }
 
     const actual = propertyHelpers.convertYesNoToBoolean(source)
@@ -168,8 +168,8 @@ describe('PropertyHelpers: Check if an object has a property that is also an obj
   it('Should return true if an object is found in an object', function () {
     const source = {
       foo: {
-        bar: 1
-      }
+        bar: 1,
+      },
     }
 
     const actual = propertyHelpers.hasObjectProperty(source, 'foo')
@@ -178,7 +178,7 @@ describe('PropertyHelpers: Check if an object has a property that is also an obj
   })
   it('Should return false if the property is not an object', function () {
     const source = {
-      foo: 1
+      foo: 1,
     }
 
     const actual = propertyHelpers.hasObjectProperty(source, 'foo')
@@ -191,8 +191,8 @@ describe('PropertyHelpers: Check if an object has a property with hasProperty', 
   it('Should return true if an object is found in an object', function () {
     const source = {
       foo: {
-        bar: 1
-      }
+        bar: 1,
+      },
     }
 
     const actual = propertyHelpers.hasProperty(source, 'foo')
@@ -201,7 +201,7 @@ describe('PropertyHelpers: Check if an object has a property with hasProperty', 
   })
   it('Should return false if the property does not exist', function () {
     const source = {
-      bar: 1
+      bar: 1,
     }
 
     const actual = propertyHelpers.hasProperty(source, 'foo')
@@ -214,7 +214,7 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
   it('Should convert an empty string to null', function () {
     const source = {
       foo: 'foo',
-      bar: null
+      bar: null,
     }
     const actual = propertyHelpers.convertNestedObjects(source, ['bar'])
     expect(actual.bar).be.null
@@ -222,17 +222,17 @@ describe('PropertyHelpers: Conversion of nested objects', function () {
   it('Should convert a string to a nested object', function () {
     const source = {
       foo: 'foo',
-      bar: 'some-id'
+      bar: 'some-id',
     }
     const actual = propertyHelpers.convertNestedObjects(source, ['bar'])
     expect(actual.bar).to.deep.equal({
-      id: 'some-id'
+      id: 'some-id',
     })
   })
   it('Should do nothing if props is not passed in', function () {
     const source = {
       foo: 'foo',
-      bar: 'some-id'
+      bar: 'some-id',
     }
     const actual = propertyHelpers.convertNestedObjects(source)
     expect(actual).to.deep.equal(source)

--- a/test/lib/transform-sectors.test.js
+++ b/test/lib/transform-sectors.test.js
@@ -68,7 +68,7 @@ describe('Sectors transformer', () => {
       const sector = transformSectors.getSectorForName('Advanced Engineering', sectorList)
       expect(sector).to.eql({
         id: 'af959812-6095-e211-a939-e4115bead28a',
-        name: 'Advanced Engineering'
+        name: 'Advanced Engineering',
       })
     })
   })

--- a/test/lib/url-helpers.test.js
+++ b/test/lib/url-helpers.test.js
@@ -3,7 +3,7 @@ const urlHelpers = require('~/src/lib/url-helpers')
 describe('buildQueryString', function () {
   it('should build the expected query string for a single param', function () {
     const params = {
-      mock: 'mockParam'
+      mock: 'mockParam',
     }
     const queryString = urlHelpers.buildQueryString(params)
 
@@ -14,7 +14,7 @@ describe('buildQueryString', function () {
     const params = {
       mock: 'mockParam',
       mock1: 'mockParam1',
-      mock2: 'mockParam2'
+      mock2: 'mockParam2',
     }
     const queryString = urlHelpers.buildQueryString(params)
 

--- a/test/middleware/auth.test.js
+++ b/test/middleware/auth.test.js
@@ -15,7 +15,7 @@ describe('Auth middleware', () => {
     describe('when request contains an allowed url', () => {
       it('call the next middleware', () => {
         const reqMock = {
-          url: '/login'
+          url: '/login',
         }
 
         this.authMiddleware(reqMock, resMock, this.nextSpy)
@@ -30,8 +30,8 @@ describe('Auth middleware', () => {
       const reqMock = {
         url: '',
         session: {
-          token: 'abcd'
-        }
+          token: 'abcd',
+        },
       }
 
       this.authMiddleware(reqMock, resMock, this.nextSpy)
@@ -45,10 +45,10 @@ describe('Auth middleware', () => {
       const reqMock = {
         url: '/protected-url',
         originalUrl: '/protected-url',
-        session: {}
+        session: {},
       }
       const resMock = {
-        redirect: this.sandbox.stub()
+        redirect: this.sandbox.stub(),
       }
 
       this.authMiddleware(reqMock, resMock, this.nextSpy)

--- a/test/middleware/errors.test.js
+++ b/test/middleware/errors.test.js
@@ -15,8 +15,8 @@ describe('Error Middleware Test', () => {
     this.errorsStub = (isDev) => {
       return proxyquire('../../src/middleware/errors', {
         '../config': {
-          isDev
-        }
+          isDev,
+        },
       })
     }
   })
@@ -45,10 +45,10 @@ describe('Error Middleware Test', () => {
       const mockResponse = {
         status: () => {
           return {
-            render: responseRenderSpy
+            render: responseRenderSpy,
           }
         },
-        headersSent: false
+        headersSent: false,
       }
       const responsestatusCodeSpy = this.sandbox.spy(mockResponse, 'status')
       const error = new Error(`mock ${errorCode404} error`)
@@ -63,7 +63,7 @@ describe('Error Middleware Test', () => {
       expect(responseRenderSpy.args[0][1]).to.eql({
         'devErrorDetail': error,
         'statusCode': errorCode404,
-        'statusMessage': 'Sorry we couldn\'t find that page!'
+        'statusMessage': 'Sorry we couldn\'t find that page!',
       })
       expect(this.winstonInfoStub.args[0][0] instanceof Error).to.be.true
       expect(this.winstonInfoStub.args[0][0].message).to.equal(`mock ${errorCode404} error`)
@@ -76,10 +76,10 @@ describe('Error Middleware Test', () => {
       const mockResponse = {
         status: () => {
           return {
-            render: responseRenderSpy
+            render: responseRenderSpy,
           }
         },
-        headersSent: false
+        headersSent: false,
       }
       const responsestatusCodeSpy = this.sandbox.spy(mockResponse, 'status')
       const error = new Error(`mock ${errorCode500} error`)
@@ -93,7 +93,7 @@ describe('Error Middleware Test', () => {
       expect(responseRenderSpy.args[0][1]).to.eql({
         'devErrorDetail': error,
         'statusCode': errorCode500,
-        'statusMessage': 'Sorry something has gone wrong!'
+        'statusMessage': 'Sorry something has gone wrong!',
       })
       expect(this.winstonErrorStub.args[0][0] instanceof Error).to.be.true
       expect(this.winstonErrorStub.args[0][0].message).to.equal(`mock ${errorCode500} error`)
@@ -106,10 +106,10 @@ describe('Error Middleware Test', () => {
       const mockResponse = {
         status: () => {
           return {
-            render: responseRenderSpy
+            render: responseRenderSpy,
           }
         },
-        headersSent: false
+        headersSent: false,
       }
       const responsestatusCodeSpy = this.sandbox.spy(mockResponse, 'status')
       const error = new Error(`mock ${errorCode403} error`)
@@ -126,7 +126,7 @@ describe('Error Middleware Test', () => {
       expect(responseRenderSpy.args[0][1]).to.eql({
         'devErrorDetail': error,
         'statusCode': errorCode403,
-        'statusMessage': 'This form has been tampered with'
+        'statusMessage': 'This form has been tampered with',
       })
       expect(this.winstonErrorStub.args[0][0] instanceof Error).to.be.true
       expect(this.winstonErrorStub.args[0][0].message).to.equal(`mock ${errorCode403} error`)
@@ -140,10 +140,10 @@ describe('Error Middleware Test', () => {
       const mockResponse = {
         status: () => {
           return {
-            render: responseRenderSpy
+            render: responseRenderSpy,
           }
         },
-        headersSent: false
+        headersSent: false,
       }
       const responsestatusCodeSpy = this.sandbox.spy(mockResponse, 'status')
       const error = new Error(`mock ${errorCode500} error`)
@@ -157,7 +157,7 @@ describe('Error Middleware Test', () => {
       expect(responseRenderSpy.args[0][1]).to.eql({
         'devErrorDetail': false,
         'statusCode': errorCode500,
-        'statusMessage': 'Sorry something has gone wrong!'
+        'statusMessage': 'Sorry something has gone wrong!',
       })
       expect(this.winstonErrorStub.args[0][0] instanceof Error).to.be.true
       expect(this.winstonErrorStub.args[0][0].message).to.equal(`mock ${errorCode500} error`)
@@ -167,7 +167,7 @@ describe('Error Middleware Test', () => {
     it('should drop through to next middleware as headers have already been sent', () => {
       const nextSpy = this.sandbox.spy()
       const mockResponse = {
-        headersSent: true
+        headersSent: true,
       }
       const error = new Error('mock headers sent error')
 

--- a/test/nunjucks.js
+++ b/test/nunjucks.js
@@ -5,7 +5,7 @@ const filters = require('@uktrade/trade_elements/dist/nunjucks/filters')
 
 nunjucks.configure('views')
 const nunenv = nunjucks.configure([`${__dirname}/../src/views`, `${__dirname}/../node_modules/@uktrade/trade_elements/dist/nunjucks`], {
-  autoescape: true
+  autoescape: true,
 })
 
 Object.keys(filters).forEach((filterName) => {

--- a/test/repos/company.repo.test.js
+++ b/test/repos/company.repo.test.js
@@ -10,7 +10,7 @@ describe('Company repository', () => {
           return new Promise((resolve) => {
             resolve({
               id: '1234',
-              name: 'fred'
+              name: 'fred',
             })
           })
         }
@@ -35,14 +35,14 @@ describe('Company repository', () => {
           return new Promise((resolve, reject) => {
             reject({
               error: {
-                sector: ['error with sector']
+                sector: ['error with sector'],
               },
               message: '400 - {"sector":["error with sector"]}',
               name: 'StatusCodeError',
               response: {
                 statusCode: 400,
-                statusMessage: 'Bad Request'
-              }
+                statusMessage: 'Bad Request',
+              },
             })
           })
         }
@@ -78,7 +78,7 @@ describe('Company repository', () => {
             })
             .catch((error) => {
               expect(error.errors).to.eql({
-                sector: ['error with sector']
+                sector: ['error with sector'],
               })
               done()
             })
@@ -92,8 +92,8 @@ describe('Company repository', () => {
               error: { 'detail': 'Service Unavailable' },
               name: 'StatusCodeError',
               response: {
-                statusCode: 501
-              }
+                statusCode: 501,
+              },
             })
           })
         }
@@ -134,8 +134,8 @@ describe('Company repository', () => {
               name: 'StatusCodeError',
               response: {
                 statusCode: 501,
-                statusMessage: 'Service Unavailable'
-              }
+                statusMessage: 'Service Unavailable',
+              },
             })
           })
         }
@@ -241,7 +241,7 @@ describe('Company repository', () => {
 
   function makeRepositoryWithAuthRequest (authorisedRequestStub) {
     return proxyquire('~/src/repos/company.repo', {
-      '../lib/authorised-request': authorisedRequestStub
+      '../lib/authorised-request': authorisedRequestStub,
     })
   }
 

--- a/test/repos/investment.repo.test.js
+++ b/test/repos/investment.repo.test.js
@@ -7,7 +7,7 @@ const {
   getInvestmentValue,
   getInvestmentRequirements,
   createInvestmentProject,
-  updateInvestmentProject
+  updateInvestmentProject,
 } = require('~/src/repos/investment.repo')
 
 const companyData = require('../data/company.json')

--- a/test/services/company-form.service.test.js
+++ b/test/services/company-form.service.test.js
@@ -9,12 +9,12 @@ describe('company form service', function () {
 
     companyFormService = proxyquire('~/src/services/company-form.service', {
       '../repos/company.repo': {
-        saveCompany: saveCompanyStub
+        saveCompany: saveCompanyStub,
       },
       '../repos/metadata.repo': {
         businessTypeOptions: [{ id: '80756b9a-5d95-e211-a939-e4115bead28a', name: 'Private Limited Company' }],
-        getIdForName: metadatarepository.getIdForName
-      }
+        getIdForName: metadatarepository.getIdForName,
+      },
     })
   })
 
@@ -48,7 +48,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: { id: 'e1', name: '1-100' },
-        turnover_range: null
+        turnover_range: null,
       }
       const expected = {
         id: '1234',
@@ -78,7 +78,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: 'e1',
-        turnover_range: null
+        turnover_range: null,
       }
       const actual = companyFormService.getLtdCompanyAsFormData(company)
       expect(actual).to.deep.equal(expected)
@@ -112,7 +112,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: { id: 'e1', name: '1-100' },
-        turnover_range: null
+        turnover_range: null,
       }
       const expected = {
         id: '1234',
@@ -141,7 +141,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: 'e1',
-        turnover_range: null
+        turnover_range: null,
       }
       const actual = companyFormService.getUkOtherCompanyAsFormData(company)
       expect(actual).to.deep.equal(expected)
@@ -175,7 +175,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: { id: 'e1', name: '1-100' },
-        turnover_range: null
+        turnover_range: null,
       }
       const expected = {
         id: '1234',
@@ -203,7 +203,7 @@ describe('company form service', function () {
         website: 'http://www.test.com',
         description: 'description',
         employee_range: 'e1',
-        turnover_range: null
+        turnover_range: null,
       }
       const actual = companyFormService.getForeignCompanyAsFormData(company)
       expect(actual).to.deep.equal(expected)
@@ -232,8 +232,8 @@ describe('company form service', function () {
         incorporation_date: '2017-02-15',
         registered_address_country: {
           id: '80756b9a-5d95-e211-a939-e4115bead28a',
-          name: 'United Kingdom'
-        }
+          name: 'United Kingdom',
+        },
       }
 
       const expected = {
@@ -248,7 +248,7 @@ describe('company form service', function () {
         registered_address_town: 'PRESTON',
         registered_address_county: null,
         registered_address_postcode: 'PR1 0LS',
-        registered_address_country: '80756b9a-5d95-e211-a939-e4115bead28a'
+        registered_address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
       }
 
       const formData = companyFormService.getDefaultLtdFormForCH(chCompany)
@@ -260,7 +260,7 @@ describe('company form service', function () {
     it('saves company data to repository', function () {
       const company = {
         thing: 'yes',
-        other: 'no'
+        other: 'no',
       }
       return companyFormService.saveCompanyForm('1234', company)
         .then((result) => {
@@ -270,7 +270,7 @@ describe('company form service', function () {
     it('converts yes/no to true/false', function () {
       const company = {
         thing: 'yes',
-        other: 'no'
+        other: 'no',
       }
       return companyFormService.saveCompanyForm('1234', company)
         .then((result) => {
@@ -279,7 +279,7 @@ describe('company form service', function () {
     })
     it('nulls empty fields', function () {
       const company = {
-        thing: ''
+        thing: '',
       }
       return companyFormService.saveCompanyForm('1234', company)
         .then((result) => {
@@ -290,8 +290,8 @@ describe('company form service', function () {
       saveCompanyStub = sinon.stub().rejects({ error: 'test' })
       companyFormService = proxyquire('~/src/services/company-form.service', {
         '../repos/company.repo': {
-          saveCompany: saveCompanyStub
-        }
+          saveCompany: saveCompanyStub,
+        },
       })
       const company = { thing: '' }
 

--- a/test/services/company-formatting.service.test.js
+++ b/test/services/company-formatting.service.test.js
@@ -26,11 +26,11 @@ describe('Company formatting service', () => {
           'incorporation_date': '2012-02-06',
           'registered_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
-          }
+            'name': 'United Kingdom',
+          },
         },
         'contacts': [],
-        'interactions': []
+        'interactions': [],
       }
       const actual = companyFormattingService.getDisplayCompany(company)
       expect(actual).to.be.null
@@ -48,8 +48,8 @@ describe('Company formatting service', () => {
           'future_interest_countries': [
             {
               'id': '300be5c4-5d95-e211-a939-e4115bead28a',
-              'name': 'Sweden'
-            }
+              'name': 'Sweden',
+            },
           ],
           'uk_based': true,
           'account_manager': {
@@ -63,10 +63,10 @@ describe('Company formatting service', () => {
             'email': 'yvonne.ahern@mobile.ukti.gov.uk',
             'dit_team': {
               'id': '3a48318c-9698-e211-a939-e4115bead28a',
-              'name': 'ITFG - E-Business Operational Support Team'
+              'name': 'ITFG - E-Business Operational Support Team',
             },
             'groups': [],
-            'user_permissions': []
+            'user_permissions': [],
           },
           'registered_address_1': 'Business Innovation & Skills',
           'registered_address_2': '1 Victoria Street',
@@ -75,7 +75,7 @@ describe('Company formatting service', () => {
           'registered_address_town': 'London',
           'registered_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
+            'name': 'United Kingdom',
           },
           'registered_address_county': 'Greater London',
           'registered_address_postcode': 'SW1H 0ET',
@@ -96,29 +96,29 @@ describe('Company formatting service', () => {
           'trading_address_town': 'London',
           'trading_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
+            'name': 'United Kingdom',
           },
           'trading_address_county': 'Greater London',
           'trading_address_postcode': 'SW1H 0ET',
           'archived_by': null,
           'business_type': {
             'id': '98d14e94-5d95-e211-a939-e4115bead28a',
-            'name': 'Company'
+            'name': 'Company',
           },
           'headquarter_type': {
             'id': 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
-            'name': 'ehq'
+            'name': 'ehq',
           },
           'sector': {
             'id': 'a638cecc-5f95-e211-a939-e4115bead28a',
-            'name': 'Giftware, Jewellery and Tableware'
+            'name': 'Giftware, Jewellery and Tableware',
           },
           'employee_range': null,
           'turnover_range': null,
           'uk_region': {
             'id': '874cd12a-6095-e211-a939-e4115bead28a',
-            'name': 'London'
-          }
+            'name': 'London',
+          },
         }
         const expected = {
           business_type: 'Company',
@@ -134,7 +134,7 @@ describe('Company formatting service', () => {
           employee_range: null,
           turnover_range: null,
           account_manager: 'Yvonne Ahern',
-          country: 'United Kingdom'
+          country: 'United Kingdom',
         }
         const actual = companyFormattingService.getDisplayCompany(company)
         expect(actual).to.deep.equal(expected)
@@ -142,7 +142,7 @@ describe('Company formatting service', () => {
       it('should convert website to link', () => {
         const company = {
           'id': '1234',
-          'website': 'http:/www.test.com'
+          'website': 'http:/www.test.com',
         }
 
         const actual = companyFormattingService.getDisplayCompany(company)
@@ -161,7 +161,7 @@ describe('Company formatting service', () => {
           'registered_address_town': 'London',
           'registered_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'Spain'
+            'name': 'Spain',
           },
           'registered_address_county': 'Greater London',
           'registered_address_postcode': 'SW1H 0ET',
@@ -174,8 +174,8 @@ describe('Company formatting service', () => {
           'trading_address_postcode': 'WC1 1AA',
           'trading_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
-          }
+            'name': 'United Kingdom',
+          },
         }
 
         const actual = companyFormattingService.getDisplayCompany(company)
@@ -194,7 +194,7 @@ describe('Company formatting service', () => {
           'registered_address_town': 'London',
           'registered_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'Spain'
+            'name': 'Spain',
           },
           'registered_address_county': 'Greater London',
           'registered_address_postcode': 'SW1H 0ET',
@@ -207,12 +207,12 @@ describe('Company formatting service', () => {
           'trading_address_postcode': 'WC1 1AA',
           'trading_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
+            'name': 'United Kingdom',
           },
           'sector': {
             'id': 'a638cecc-5f95-e211-a939-e4115bead28a',
-            'name': 'Computers : Tech'
-          }
+            'name': 'Computers : Tech',
+          },
         }
 
         const actual = companyFormattingService.getDisplayCompany(company)
@@ -230,8 +230,8 @@ describe('Company formatting service', () => {
           'future_interest_countries': [
             {
               'id': '300be5c4-5d95-e211-a939-e4115bead28a',
-              'name': 'Sweden'
-            }
+              'name': 'Sweden',
+            },
           ],
           'uk_based': true,
           'account_manager': {
@@ -245,10 +245,10 @@ describe('Company formatting service', () => {
             'email': 'yvonne.ahern@mobile.ukti.gov.uk',
             'dit_team': {
               'id': '3a48318c-9698-e211-a939-e4115bead28a',
-              'name': 'ITFG - E-Business Operational Support Team'
+              'name': 'ITFG - E-Business Operational Support Team',
             },
             'groups': [],
-            'user_permissions': []
+            'user_permissions': [],
           },
           'registered_address_1': 'Business Innovation & Skills',
           'registered_address_2': '1 Victoria Street',
@@ -257,7 +257,7 @@ describe('Company formatting service', () => {
           'registered_address_town': 'London',
           'registered_address_country': {
             'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-            'name': 'United Kingdom'
+            'name': 'United Kingdom',
           },
           'registered_address_county': 'Greater London',
           'registered_address_postcode': 'SW1H 0ET',
@@ -281,19 +281,19 @@ describe('Company formatting service', () => {
           'archived_by': null,
           'business_type': {
             'id': '98d14e94-5d95-e211-a939-e4115bead28a',
-            'name': 'Company'
+            'name': 'Company',
           },
           'sector': {
             'id': 'a638cecc-5f95-e211-a939-e4115bead28a',
-            'name': 'Giftware, Jewellery and Tableware'
+            'name': 'Giftware, Jewellery and Tableware',
           },
           'employee_range': null,
           'turnover_range': null,
           'uk_region': {
             'id': '874cd12a-6095-e211-a939-e4115bead28a',
-            'name': 'London'
+            'name': 'London',
           },
-          'trading_address_country': null
+          'trading_address_country': null,
         }
         it('and show the CDMS company type', () => {
           const actual = companyFormattingService.getDisplayCompany(company)
@@ -329,8 +329,8 @@ describe('Company formatting service', () => {
         'incorporation_date': '2012-02-06',
         'registered_address_country': {
           'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-          'name': 'United Kingdom'
-        }
+          'name': 'United Kingdom',
+        },
       }
       const actual = companyFormattingService.getDisplayCH(company)
       const expected = {
@@ -340,7 +340,7 @@ describe('Company formatting service', () => {
         name: 'Amazon Savers',
         company_status: 'Active',
         sic_code: ['82990 - Other business support service activities n.e.c.', '82991 - Other business support service activities n.e.c.'],
-        incorporation_date: '6 February 2012'
+        incorporation_date: '6 February 2012',
       }
       expect(actual).to.deep.equal(expected)
     })

--- a/test/services/company.service.test.js
+++ b/test/services/company.service.test.js
@@ -14,7 +14,7 @@ describe('get header address', () => {
       'registered_address_town': 'London',
       'registered_address_country': {
         'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-        'name': 'United Kingdom'
+        'name': 'United Kingdom',
       },
       'registered_address_county': 'Greater London',
       'registered_address_postcode': 'SW1H 0ET',
@@ -27,8 +27,8 @@ describe('get header address', () => {
       'trading_address_postcode': 'WC1 1AA',
       'trading_address_country': {
         'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-        'name': 'United Kingdom'
-      }
+        'name': 'United Kingdom',
+      },
     }
 
     const address = companyService.getHeadingAddress(company)
@@ -48,7 +48,7 @@ describe('get header address', () => {
       'registered_address_town': 'London',
       'registered_address_country': {
         'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-        'name': 'United Kingdom'
+        'name': 'United Kingdom',
       },
       'registered_address_county': 'Greater London',
       'registered_address_postcode': 'SW1H 0ET',
@@ -59,7 +59,7 @@ describe('get header address', () => {
       'trading_address_town': null,
       'trading_address_county': null,
       'trading_address_postcode': null,
-      'trading_address_country': null
+      'trading_address_country': null,
     }
     const address = companyService.getHeadingAddress(company)
     expect(address).to.equal('Business Innovation & Skills, 1 Victoria Street, London, Greater London, SW1H 0ET, United Kingdom')
@@ -90,8 +90,8 @@ describe('get header address', () => {
         'incorporation_date': '2012-02-06',
         'registered_address_country': {
           'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-          'name': 'United Kingdom'
-        }
+          'name': 'United Kingdom',
+        },
       },
       'registered_address_1': 'Business Innovation & Skills',
       'registered_address_2': '1 Victoria Street',
@@ -100,7 +100,7 @@ describe('get header address', () => {
       'registered_address_town': 'London',
       'registered_address_country': {
         'id': '80756b9a-5d95-e211-a939-e4115bead28a',
-        'name': 'United Kingdom'
+        'name': 'United Kingdom',
       },
       'registered_address_county': 'Greater London',
       'registered_address_postcode': 'SW1H 0ET',
@@ -111,7 +111,7 @@ describe('get header address', () => {
       'trading_address_town': null,
       'trading_address_county': null,
       'trading_address_postcode': null,
-      'trading_address_country': null
+      'trading_address_country': null,
     }
     const address = companyService.getHeadingAddress(company)
     expect(address).to.equal('52a High Street, Sheffield, S20 1ED, United Kingdom')
@@ -122,7 +122,7 @@ describe('buildCompanyUrl', () => {
   it('should return expected url for non uk based company', () => {
     const urlPath = companyService.buildCompanyUrl({
       uk_based: false,
-      id: 'mockId'
+      id: 'mockId',
     })
 
     expect(urlPath).to.equal('/company/view/foreign/mockId')
@@ -131,9 +131,9 @@ describe('buildCompanyUrl', () => {
     const urlPath = companyService.buildCompanyUrl({
       uk_based: true,
       business_type: {
-        name: 'private limited company'
+        name: 'private limited company',
       },
-      id: 'mockId'
+      id: 'mockId',
     })
 
     expect(urlPath).to.equal('/company/view/ltd/mockId')
@@ -142,9 +142,9 @@ describe('buildCompanyUrl', () => {
     const urlPath = companyService.buildCompanyUrl({
       uk_based: true,
       business_type: {
-        name: 'public limited company'
+        name: 'public limited company',
       },
-      id: 'mockId'
+      id: 'mockId',
     })
 
     expect(urlPath).to.equal('/company/view/ltd/mockId')
@@ -153,9 +153,9 @@ describe('buildCompanyUrl', () => {
     const urlPath = companyService.buildCompanyUrl({
       uk_based: true,
       business_type: {
-        name: 'PUBLIC LIMITED COMPANY'
+        name: 'PUBLIC LIMITED COMPANY',
       },
-      id: 'mockId'
+      id: 'mockId',
     })
 
     expect(urlPath).to.equal('/company/view/ltd/mockId')
@@ -164,9 +164,9 @@ describe('buildCompanyUrl', () => {
     const urlPath = companyService.buildCompanyUrl({
       uk_based: true,
       business_type: {
-        name: 'a different company type'
+        name: 'a different company type',
       },
-      id: 'mockId'
+      id: 'mockId',
     })
 
     expect(urlPath).to.equal('/company/view/ukother/mockId')

--- a/test/services/contact-form.service.test.js
+++ b/test/services/contact-form.service.test.js
@@ -25,8 +25,8 @@ describe('contact form service', function () {
 
             resolve(contactForm)
           })
-        }
-      }
+        },
+      },
     })
   })
 
@@ -44,7 +44,7 @@ describe('contact form service', function () {
         address_town: 'Town view',
         address_country: {
           id: '81756b9a-5d95-e211-a939-e4115bead28a',
-          name: 'United States'
+          name: 'United States',
         },
         address_county: 'CA',
         address_postcode: '94043',
@@ -67,13 +67,13 @@ describe('contact form service', function () {
         archived_by: null,
         title: {
           id: '0167b456-0ddd-49bd-8184-e3227a0b6396',
-          name: 'Undefined'
+          name: 'Undefined',
         },
         company: {
           id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
-          name: 'OpenStuff'
+          name: 'OpenStuff',
         },
-        advisor: null
+        advisor: null,
       }
     })
 
@@ -100,7 +100,7 @@ describe('contact form service', function () {
         address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
         telephone_alternative: '999',
         email_alternative: 'fred@me.com',
-        notes: 'Some notes'
+        notes: 'Some notes',
       }
 
       const actual = contactFormService.getContactAsFormData(contact)
@@ -140,7 +140,7 @@ describe('contact form service', function () {
         address_country: null,
         telephone_alternative: '999',
         email_alternative: 'fred@me.com',
-        notes: 'Some notes'
+        notes: 'Some notes',
       }
 
       const actual = contactFormService.getContactAsFormData(contact)
@@ -177,7 +177,7 @@ describe('contact form service', function () {
         address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
         telephone_alternative: '999',
         email_alternative: 'fred@me.com',
-        notes: 'Some notes'
+        notes: 'Some notes',
       }
     })
 
@@ -185,10 +185,10 @@ describe('contact form service', function () {
       const expected = {
         id: '50680966-f5e1-e311-8a2b-e4115bead28a',
         company: {
-          id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a'
+          id: '44ea1e01-f5e1-e311-8a2b-e4115bead28a',
         },
         title: {
-          id: '0167b456-0ddd-49bd-8184-e3227a0b6396'
+          id: '0167b456-0ddd-49bd-8184-e3227a0b6396',
         },
         first_name: 'Zac',
         last_name: 'Baman',
@@ -206,11 +206,11 @@ describe('contact form service', function () {
         address_county: 'CA',
         address_postcode: '94043',
         address_country: {
-          id: '81756b9a-5d95-e211-a939-e4115bead28a'
+          id: '81756b9a-5d95-e211-a939-e4115bead28a',
         },
         telephone_alternative: '999',
         email_alternative: 'fred@me.com',
-        notes: 'Some notes'
+        notes: 'Some notes',
       }
 
       return contactFormService.saveContactForm('1234', formData)

--- a/test/services/contact-formatting.service.test.js
+++ b/test/services/contact-formatting.service.test.js
@@ -33,15 +33,15 @@ describe('Contact formatting service', function () {
       archived_by: null,
       title: {
         id: 'a26cb21e-6095-e211-a939-e4115bead28a',
-        name: 'Mr'
+        name: 'Mr',
       },
       advisor: null,
-      address_country: null
+      address_country: null,
     }
 
     company = {
       id: '9876',
-      'name': 'My Coorp'
+      'name': 'My Coorp',
     }
   })
   describe('contact details', function () {
@@ -53,7 +53,7 @@ describe('Contact formatting service', function () {
         address: '10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
         telephone_alternative: '07814 000 333',
         email_alternative: 'fred@gmail.com',
-        notes: 'some notes'
+        notes: 'some notes',
       }
 
       const actual = contactFormattingService.getDisplayContact(contact, company)
@@ -75,7 +75,7 @@ describe('Contact formatting service', function () {
         trading_address_4: '',
         trading_address_town: 'Medium Town',
         trading_address_county: 'Medium County',
-        trading_address_postcode: 'TT1 1TT'
+        trading_address_postcode: 'TT1 1TT',
       }
 
       contact.address_1 = ''
@@ -107,7 +107,7 @@ describe('Contact formatting service', function () {
         trading_address_4: '',
         trading_address_town: '',
         trading_address_county: '',
-        trading_address_postcode: ''
+        trading_address_postcode: '',
       }
 
       contact.address_1 = ''
@@ -137,7 +137,7 @@ describe('Contact formatting service', function () {
         address: '10 The Street, Warble, Big Town, Large County, LL1 1LL, United Kingdom',
         email_alternative: 'fred@gmail.com',
         notes: 'some notes',
-        telephone_alternative: '07814 000 333'
+        telephone_alternative: '07814 000 333',
       }
 
       const actual = contactFormattingService.getDisplayCompanyContact(contact, company)
@@ -159,7 +159,7 @@ describe('Contact formatting service', function () {
         trading_address_4: '',
         trading_address_town: 'Medium Town',
         trading_address_county: 'Medium County',
-        trading_address_postcode: 'TT1 1TT'
+        trading_address_postcode: 'TT1 1TT',
       }
 
       contact.address_1 = ''
@@ -191,7 +191,7 @@ describe('Contact formatting service', function () {
         trading_address_4: '',
         trading_address_town: '',
         trading_address_county: '',
-        trading_address_postcode: ''
+        trading_address_postcode: '',
       }
       contact.address_1 = ''
       contact.address_2 = ''
@@ -212,7 +212,7 @@ describe('Contact formatting service', function () {
     contact.archived_reason = 'Left company'
     contact.archived_by = {
       first_name: 'Fred',
-      last_name: 'Flintstone'
+      last_name: 'Flintstone',
     }
     contact.archived_on = '2017-02-14T14:49:17'
 
@@ -222,7 +222,7 @@ describe('Contact formatting service', function () {
       job_title: 'Director',
       reason: 'Left company',
       archived_by: 'Fred Flintstone',
-      archived_on: '14 Feb 2017'
+      archived_on: '14 Feb 2017',
     }
 
     const actual = contactFormattingService.getDisplayArchivedCompanyContact(contact, company)

--- a/test/services/dashboard.service.test.js
+++ b/test/services/dashboard.service.test.js
@@ -2,11 +2,11 @@ describe('Dashboard service', () => {
   function getDashboardService (mockData) {
     return proxyquire('~/src/services/dashboard.service', {
       './company.service': {
-        buildCompanyUrl: sinon.stub().returns('/test')
+        buildCompanyUrl: sinon.stub().returns('/test'),
       },
       '../lib/authorised-request': () => new Promise((resolve) => {
         resolve(mockData)
-      })
+      }),
     })
   }
 
@@ -17,8 +17,8 @@ describe('Dashboard service', () => {
         subject: 'int-subject',
         company: {
           'id': 'comp-id',
-          'name': 'comp-name'
-        }
+          'name': 'comp-name',
+        },
       }],
       contacts: [{
         id: 'contact-id',
@@ -26,9 +26,9 @@ describe('Dashboard service', () => {
         last_name: 'last-name',
         company: {
           'id': 'comp-id',
-          'name': 'comp-name'
-        }
-      }]
+          'name': 'comp-name',
+        },
+      }],
     }
     const dashboardService = getDashboardService(mockHomepageData)
 
@@ -41,8 +41,8 @@ describe('Dashboard service', () => {
             url: '/interaction/int-id/details',
             company: {
               url: '/test',
-              name: 'comp-name'
-            }
+              name: 'comp-name',
+            },
           }],
           contacts: [{
             id: 'contact-id',
@@ -51,9 +51,9 @@ describe('Dashboard service', () => {
             company: {
               url: '/test',
               name: 'comp-name',
-              id: 'comp-id'
-            }
-          }]
+              id: 'comp-id',
+            },
+          }],
         })
       })
   })
@@ -63,7 +63,7 @@ describe('Dashboard service', () => {
       interactions: [{
         id: 'int-id',
         subject: 'int-subject',
-        company: null
+        company: null,
       }],
       contacts: [{
         id: 'contact-id',
@@ -71,9 +71,9 @@ describe('Dashboard service', () => {
         last_name: 'last-name',
         company: {
           'id': 'comp-id',
-          'name': 'comp-name'
-        }
-      }]
+          'name': 'comp-name',
+        },
+      }],
     }
     const dashboardService = getDashboardService(mockHomepageData)
 
@@ -86,8 +86,8 @@ describe('Dashboard service', () => {
             url: '/interaction/int-id/details',
             company: {
               url: null,
-              name: null
-            }
+              name: null,
+            },
           }],
           contacts: [{
             id: 'contact-id',
@@ -96,9 +96,9 @@ describe('Dashboard service', () => {
             company: {
               url: '/test',
               name: 'comp-name',
-              id: 'comp-id'
-            }
-          }]
+              id: 'comp-id',
+            },
+          }],
         })
       })
   })

--- a/test/services/interaction-data.service.test.js
+++ b/test/services/interaction-data.service.test.js
@@ -25,17 +25,17 @@ describe('interaction data service', function () {
 
     interactionDataService = proxyquire('~/src/services/interaction-data.service', {
       '../repos/company.repo': {
-        getDitCompany: getDitCompanyStub
+        getDitCompany: getDitCompanyStub,
       },
       '../repos/contact.repo': {
-        getContact: getContactStub
+        getContact: getContactStub,
       },
       '../repos/interaction.repo': {
-        getInteraction: getInteractionStub
+        getInteraction: getInteractionStub,
       },
       '../repos/metadata.repo': {
-        interactionTypeOptions: [interaction_type]
-      }
+        interactionTypeOptions: [interaction_type],
+      },
     })
   })
 
@@ -54,17 +54,17 @@ describe('interaction data service', function () {
 
       interactionDataService = proxyquire('~/src/services/interaction-data.service', {
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/contact.repo': {
-          getContact: getContactStub
+          getContact: getContactStub,
         },
         '../repos/interaction.repo': {
-          getInteraction: getInteractionStub
+          getInteraction: getInteractionStub,
         },
         '../repos/metadata.repo': {
-          interactionTypeOptions: [interaction_type]
-        }
+          interactionTypeOptions: [interaction_type],
+        },
       })
       interactionDataService.getHydratedInteraction(token, '1234')
       .catch(() => {
@@ -110,17 +110,17 @@ describe('interaction data service', function () {
 
       interactionDataService = proxyquire('~/src/services/interaction-data.service', {
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/contact.repo': {
-          getContact: getContactStub
+          getContact: getContactStub,
         },
         '../repos/interaction.repo': {
-          getInteraction: getInteractionStub
+          getInteraction: getInteractionStub,
         },
         '../repos/metadata.repo': {
-          interactionTypeOptions: [interaction_type]
-        }
+          interactionTypeOptions: [interaction_type],
+        },
       })
 
       interactionDataService.createBlankInteractionForContact(token, dit_advisor, interaction_type.id, 'YYY')
@@ -133,17 +133,17 @@ describe('interaction data service', function () {
 
       interactionDataService = proxyquire('~/src/services/interaction-data.service', {
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/contact.repo': {
-          getContact: getContactStub
+          getContact: getContactStub,
         },
         '../repos/interaction.repo': {
-          getInteraction: getInteractionStub
+          getInteraction: getInteractionStub,
         },
         '../repos/metadata.repo': {
-          interactionTypeOptions: [interaction_type]
-        }
+          interactionTypeOptions: [interaction_type],
+        },
       })
       interactionDataService.createBlankInteractionForContact(token, dit_advisor, interaction_type.id, 'YYY')
       .catch((error) => {
@@ -178,17 +178,17 @@ describe('interaction data service', function () {
 
       interactionDataService = proxyquire('~/src/services/interaction-data.service', {
         '../repos/company.repo': {
-          getDitCompany: getDitCompanyStub
+          getDitCompany: getDitCompanyStub,
         },
         '../repos/contact.repo': {
-          getContact: getContactStub
+          getContact: getContactStub,
         },
         '../repos/interaction.repo': {
-          getInteraction: getInteractionStub
+          getInteraction: getInteractionStub,
         },
         '../repos/metadata.repo': {
-          interactionTypeOptions: [interaction_type]
-        }
+          interactionTypeOptions: [interaction_type],
+        },
       })
       interactionDataService.createBlankInteractionForCompany(token, dit_advisor, interaction_type.id, 'YYY')
       .catch((error) => {

--- a/test/services/interaction-form.service.test.js
+++ b/test/services/interaction-form.service.test.js
@@ -29,15 +29,15 @@ describe('interaction form service', function () {
       date: '2017-01-02:T00:00:00.00Z',
       dit_advisor,
       service,
-      dit_team
+      dit_team,
     }
 
     saveInteractionStub = sinon.stub().resolves({ id: '1234', subject: 'subject', company: company.id, contact: contact.id })
 
     interactionFormService = proxyquire('~/src/services/interaction-form.service', {
       '../repos/interaction.repo': {
-        saveInteraction: saveInteractionStub
-      }
+        saveInteraction: saveInteractionStub,
+      },
     })
   })
 
@@ -53,7 +53,7 @@ describe('interaction form service', function () {
         date: '2017-01-02:T00:00:00.00Z',
         dit_advisor: dit_advisor.id,
         service: service.id,
-        dit_team: dit_team.id
+        dit_team: dit_team.id,
       }
       expect(interactionFormService.getInteractionAsFormData(interaction)).to.deep.equal(expected)
     })
@@ -66,12 +66,12 @@ describe('interaction form service', function () {
         date: '2017-01-02:T00:00:00.00Z',
         service: {
           id: null,
-          name: null
+          name: null,
         },
         dit_team: {
           id: null,
-          name: null
-        }
+          name: null,
+        },
       }
       const expected = {
         id: null,
@@ -83,7 +83,7 @@ describe('interaction form service', function () {
         date: '2017-01-02:T00:00:00.00Z',
         dit_advisor: dit_advisor.id,
         service: null,
-        dit_team: null
+        dit_team: null,
       }
       expect(interactionFormService.getInteractionAsFormData(freshInteraction)).to.deep.equal(expected)
     })
@@ -103,7 +103,7 @@ describe('interaction form service', function () {
         date_day: '12',
         dit_advisor: dit_advisor.id,
         service: service.id,
-        dit_team: dit_team.id
+        dit_team: dit_team.id,
       }
     })
 
@@ -131,8 +131,8 @@ describe('interaction form service', function () {
 
       interactionFormService = proxyquire('~/src/services/interaction-form.service', {
         '../repos/interaction.repo': {
-          saveInteraction: saveInteractionStub
-        }
+          saveInteraction: saveInteractionStub,
+        },
       })
 
       interactionFormService.saveInteractionForm(token, interactionForm)

--- a/test/services/interaction-formatting.service.test.js
+++ b/test/services/interaction-formatting.service.test.js
@@ -6,8 +6,8 @@ describe('Interaction formatting service', function () {
   beforeEach(function () {
     interactionFormattingService = proxyquire('~/src/services/interaction-formatting.service', {
       './company.service': {
-        buildCompanyUrl: sinon.stub().returns('/test')
-      }
+        buildCompanyUrl: sinon.stub().returns('/test'),
+      },
     })
 
     interaction = {
@@ -20,7 +20,7 @@ describe('Interaction formatting service', function () {
       dit_team: { id: '222', name: 'team name' },
       contact: { id: '444', first_name: 'Fred', last_name: 'Smith' },
       company: { id: '555', name: 'Fred ltd' },
-      notes: 'Here are some notes\nline 2.'
+      notes: 'Here are some notes\nline 2.',
     }
   })
 
@@ -36,7 +36,7 @@ describe('Interaction formatting service', function () {
         date: '14 Feb 2017',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -53,7 +53,7 @@ describe('Interaction formatting service', function () {
         contact: '<a href="/contact/444/details">Fred Smith</a>',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -70,7 +70,7 @@ describe('Interaction formatting service', function () {
         contact: '<a href="/contact/444/details">Smith</a>',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -87,7 +87,7 @@ describe('Interaction formatting service', function () {
         contact: '<a href="/contact/444/details">Fred</a>',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayCompanyInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -109,7 +109,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -125,7 +125,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: null,
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -141,7 +141,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -157,7 +157,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -173,7 +173,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -189,7 +189,7 @@ describe('Interaction formatting service', function () {
         date: null,
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -205,7 +205,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: null,
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -221,7 +221,7 @@ describe('Interaction formatting service', function () {
         date: '14 February 2017',
         dit_advisor: 'John Brown',
         service: 'service name',
-        dit_team: null
+        dit_team: null,
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -238,7 +238,7 @@ describe('Interaction formatting service', function () {
         date: '14 Feb 2017',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayContactInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -254,7 +254,7 @@ describe('Interaction formatting service', function () {
         advisor: null,
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayContactInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -270,7 +270,7 @@ describe('Interaction formatting service', function () {
         advisor: 'John Brown',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayContactInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)
@@ -286,7 +286,7 @@ describe('Interaction formatting service', function () {
         advisor: 'John Brown',
         service: 'service name',
         notes: 'Here are some notes<br/>line 2.',
-        dit_team: 'team name'
+        dit_team: 'team name',
       }
       const actualDisplayInteraction = interactionFormattingService.getDisplayContactInteraction(interaction)
       expect(actualDisplayInteraction).to.deep.equal(expectedDisplayInteraction)

--- a/test/services/search.service.test.js
+++ b/test/services/search.service.test.js
@@ -8,11 +8,11 @@ describe('Search service', function () {
       const searchTerm = 'testTerm'
       const searchType = 'company'
       const mockResponse = {
-        message: 'expected response'
+        message: 'expected response',
       }
       const expectedResponse = {
         message: 'expected response',
-        page: 1
+        page: 1,
       }
 
       nock(config.apiRoot)
@@ -21,14 +21,14 @@ describe('Search service', function () {
           term: searchTerm,
           entity: searchType,
           limit: 10,
-          offset: 0
+          offset: 0,
         })
         .reply(200, mockResponse)
 
       searchService.search({
         token: 'token',
         searchTerm,
-        searchType
+        searchType,
       })
         .then((response) => {
           expect(response).to.deep.equal(expectedResponse)

--- a/test/services/service-delivery-formatting.service.test.js
+++ b/test/services/service-delivery-formatting.service.test.js
@@ -6,8 +6,8 @@ describe('Service delivery formatting service', function () {
   beforeEach(function () {
     serviceDeliveryFormattingService = proxyquire('~/src/services/service-delivery-formatting.service', {
       './company.service': {
-        buildCompanyUrl: sinon.stub().returns('/test')
-      }
+        buildCompanyUrl: sinon.stub().returns('/test'),
+      },
     })
 
     serviceDelivery = {
@@ -23,7 +23,7 @@ describe('Service delivery formatting service', function () {
       uk_region: { id: '888', name: 'London' },
       sector: { id: '999', name: 'Engineering' },
       country_of_interest: { id: '122', name: 'France' },
-      dit_team: { id: '344', name: 'team name' }
+      dit_team: { id: '344', name: 'team name' },
     }
   })
 
@@ -41,7 +41,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -60,7 +60,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -79,7 +79,7 @@ describe('Service delivery formatting service', function () {
         uk_region: 'London',
         sector: 'Engineering',
         service: null,
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -98,7 +98,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -117,7 +117,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: null,
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -136,7 +136,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: null,
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -155,7 +155,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: null,
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -174,7 +174,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: 'France'
+        country_of_interest: 'France',
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)
@@ -193,7 +193,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'John Brown',
         uk_region: 'London',
         sector: 'Engineering',
-        country_of_interest: null
+        country_of_interest: null,
       }
       const actual = serviceDeliveryFormattingService.getDisplayServiceDelivery(serviceDelivery)
       expect(actual).to.deep.equal(expected)

--- a/test/services/service-delivery.service.test.js
+++ b/test/services/service-delivery.service.test.js
@@ -15,7 +15,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'b96465a6-cd5b-4a24-aff7-bf5bfc02243d',
         uk_region: 'ff5a57b9-2182-4010-9f94-586fad566b56',
         sector: '8356633c-c604-4bd2-9a9a-cd19e3ed3430',
-        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d'
+        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d',
       }
       const actual = servicedeliveryservice.convertServiceDeliveryFormToApiFormat(source)
 
@@ -78,7 +78,7 @@ describe('Service delivery formatting service', function () {
         dit_advisor: 'b96465a6-cd5b-4a24-aff7-bf5bfc02243d',
         uk_region: 'ff5a57b9-2182-4010-9f94-586fad566b56',
         sector: '8356633c-c604-4bd2-9a9a-cd19e3ed3430',
-        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d'
+        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d',
       }
       const actual = servicedeliveryservice.convertServiceDeliveryFormToApiFormat(source)
 
@@ -143,7 +143,7 @@ describe('Service delivery formatting service', function () {
         uk_region: 'ff5a57b9-2182-4010-9f94-586fad566b56',
         event: '054d059a-6c3e-445a-948f-98a41882fb84',
         sector: '8356633c-c604-4bd2-9a9a-cd19e3ed3430',
-        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d'
+        country_of_interest: '86bfa86d-a015-4260-b425-61cbf4f05a7d',
       }
       const actual = servicedeliveryservice.convertServiceDeliveryFormToApiFormat(source)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,11 @@ module.exports = {
     'service-delivery': './src/javascripts/service-delivery',
     'archive-form': './src/javascripts/archive-form',
     'add-another-field': './src/javascripts/add-another-field',
-    ie: ['html5shiv']
+    ie: ['html5shiv'],
   },
   output: {
     path: 'build/javascripts',
-    filename: '[name].bundle.js'
+    filename: '[name].bundle.js',
   },
   module: {
     loaders: [
@@ -27,36 +27,36 @@ module.exports = {
         test: /\.(js)$/,
         loader: 'babel-loader',
         query: {
-          cacheDirectory: './babel_cache'
-        }
-      }
-    ]
+          cacheDirectory: './babel_cache',
+        },
+      },
+    ],
   },
   resolve: {
     extensions: ['', '.js'],
     modules: [
       'src',
-      'node_modules'
-    ]
+      'node_modules',
+    ],
   },
   plugins: prod ? [
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': JSON.stringify('production')
-      }
+        'NODE_ENV': JSON.stringify('production'),
+      },
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false
+        warnings: false,
       },
       output: {
-        comments: false
+        comments: false,
       },
       sourceMap: false,
-      dead_code: true
+      dead_code: true,
     }),
-    new webpack.optimize.DedupePlugin()
+    new webpack.optimize.DedupePlugin(),
   ] : [
-    new webpack.optimize.DedupePlugin()
-  ]
+    new webpack.optimize.DedupePlugin(),
+  ],
 }


### PR DESCRIPTION
This turns the comma dangle rule on for eslint and fixes previous
occurrences that break the new rule.

The [reason](https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8) we won't to enforce this rule is it means cleaner diffs
when adding to an array or object and easier code manipulation.