### PR TITLE
Feature/add default search nav aggregations

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -25,6 +25,10 @@ const filters = {
 
     return string
   },
+
+  formatNumber: (number, locales = 'en-GB') => {
+    return number.toLocaleString(locales)
+  },
 }
 
 module.exports = filters

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "clean": "rm -rf build",
     "start": "node --use-strict src/server.js",
     "build": "npm run clean && npm run sass:compile && npm run js",
-    "test": "mocha --require test/common.js --ui bdd test/**/*.test.js",
+    "test": "mocha --recursive --require test/common.js --ui bdd test",
     "test:watch": "npm test -- -w",
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov mocha --require test/common.js --ui bdd test/**/*.test.js",
     "lint": "npm run lint:js && npm run lint:sass",

--- a/src/controllers/search.controller.js
+++ b/src/controllers/search.controller.js
@@ -9,19 +9,27 @@ const Celebrate = require('celebrate')
 
 const router = express.Router()
 
-function buildSearchEntityResultsData (searchEntityResults) {
-  const navItemText = {
-    company: 'Companies',
-    contact: 'Contacts',
-  }
+const defaultEntities = [
+  {
+    entity: 'company',
+    text: 'Companies',
+    count: 0,
+  },
+  {
+    entity: 'contact',
+    text: 'Contacts',
+    count: 0,
+  },
+]
 
-  return searchEntityResults.map((searchEntityResult) => {
+function buildSearchEntityResultsData (apiResponseEntities) {
+  return defaultEntities.map((defaultEntity) => {
     return Object.assign(
       {},
-      searchEntityResult,
-      {
-        text: navItemText[searchEntityResult.entity],
-      }
+      defaultEntity,
+      apiResponseEntities.find((apiResponseEntity) => {
+        return apiResponseEntity.entity === defaultEntity.entity
+      })
     )
   })
 }

--- a/src/views/_components/results-summary.njk
+++ b/src/views/_components/results-summary.njk
@@ -16,7 +16,7 @@
  #}
 <div class="results-summary">
   <span class="results-summary__count">
-    {{ total | default(0) }}
+    {{ total | default(0) | formatNumber }}
   </span> {{ (resultType | default('result')) | pluralise(total, pluralisedResultType) }} found containing
   <span class="result-summary__query">{{ searchTerm }}</span>
 </div>

--- a/src/views/_components/search-nav.njk
+++ b/src/views/_components/search-nav.njk
@@ -26,7 +26,7 @@
             {{ searchEntityResult.text }}
           </a>
         {% endif %}
-        <span class="search-nav__item-count">({{ searchEntityResult.count }})</span>
+        <span class="search-nav__item-count">({{ searchEntityResult.count | formatNumber }})</span>
       </li>
     {% endfor %}
   </ul>

--- a/test/config/nunjucks/filters.test.js
+++ b/test/config/nunjucks/filters.test.js
@@ -1,21 +1,12 @@
 const filters = require('~/config/nunjucks/filters')
 
 describe('nunjucks filters', () => {
-  beforeEach(() => {
-    this.sandbox = sinon.sandbox.create()
-    this.filters = filters
-  })
-
-  afterEach(() => {
-    this.sandbox.restore()
-  })
-
   describe('#highlight', () => {
     it('should render string with highlight', () => {
       const searchTerm = 'example term'
       const mockString = `we should see ${searchTerm} highlighted here`
 
-      const highlightedString = this.filters.highlight(mockString, searchTerm)
+      const highlightedString = filters.highlight(mockString, searchTerm)
 
       expect(highlightedString.val).to.equal(`we should see <span class="results-highlight">${searchTerm}</span> highlighted here`)
     })
@@ -24,7 +15,7 @@ describe('nunjucks filters', () => {
       const searchTerm = 'example term'
       const mockString = 'we should not see another term highlighted here'
 
-      const highlightedString = this.filters.highlight(mockString, searchTerm)
+      const highlightedString = filters.highlight(mockString, searchTerm)
 
       expect(highlightedString.val).to.equal(mockString)
     })
@@ -42,7 +33,7 @@ describe('nunjucks filters', () => {
         'another example value',
       ]
 
-      const arrayWithoutFalsies = this.filters.removeFalsey(mockArrayWithFalsies)
+      const arrayWithoutFalsies = filters.removeFalsey(mockArrayWithFalsies)
 
       expect(arrayWithoutFalsies).to.deep.equal([
         'example value',
@@ -55,7 +46,7 @@ describe('nunjucks filters', () => {
     it('should return pluralised string when count is 0', () => {
       const singularString = 'result'
 
-      const pluralisedString = this.filters.pluralise(singularString, 0)
+      const pluralisedString = filters.pluralise(singularString, 0)
 
       expect(pluralisedString).to.equal(`${singularString}s`)
     })
@@ -63,7 +54,7 @@ describe('nunjucks filters', () => {
     it('should return singular string string when count is 1', () => {
       const singularString = 'result'
 
-      const pluralisedString = this.filters.pluralise(singularString, 1)
+      const pluralisedString = filters.pluralise(singularString, 1)
 
       expect(pluralisedString).to.equal(singularString)
     })
@@ -72,7 +63,7 @@ describe('nunjucks filters', () => {
       const singularString = 'company'
       const customPluralisedString = 'companies'
 
-      const pluralisedString = this.filters.pluralise(singularString, 0, customPluralisedString)
+      const pluralisedString = filters.pluralise(singularString, 0, customPluralisedString)
 
       expect(pluralisedString).to.equal(customPluralisedString)
     })
@@ -81,7 +72,7 @@ describe('nunjucks filters', () => {
       const singularString = 'company'
       const customPluralisedString = 'companies'
 
-      const pluralisedString = this.filters.pluralise(singularString, 1, customPluralisedString)
+      const pluralisedString = filters.pluralise(singularString, 1, customPluralisedString)
 
       expect(pluralisedString).to.equal(singularString)
     })
@@ -89,13 +80,13 @@ describe('nunjucks filters', () => {
 
   describe('#formatNumber', () => {
     it('should correctly format number for "en-GB" locale', () => {
-      const formattedNumber = this.filters.formatNumber(12345678)
+      const formattedNumber = filters.formatNumber(12345678)
 
       expect(formattedNumber).to.equal('12,345,678')
     })
 
     it('should correctly format number for "de-DE" locale', () => {
-      const formattedNumber = this.filters.formatNumber(12345678, 'de-DE')
+      const formattedNumber = filters.formatNumber(12345678, 'de-DE')
 
       expect(formattedNumber).to.equal('12,345,678')
     })

--- a/test/config/nunjucks/filters.test.js
+++ b/test/config/nunjucks/filters.test.js
@@ -1,8 +1,9 @@
+const filters = require('~/config/nunjucks/filters')
 
 describe('nunjucks filters', () => {
   beforeEach(() => {
     this.sandbox = sinon.sandbox.create()
-    this.filters = require('~/config/nunjucks/filters')
+    this.filters = filters
   })
 
   afterEach(() => {
@@ -21,7 +22,7 @@ describe('nunjucks filters', () => {
 
     it('should render string without highlight', () => {
       const searchTerm = 'example term'
-      const mockString = `we should not see another term highlighted here`
+      const mockString = 'we should not see another term highlighted here'
 
       const highlightedString = this.filters.highlight(mockString, searchTerm)
 

--- a/test/config/nunjucks/filters.test.js
+++ b/test/config/nunjucks/filters.test.js
@@ -1,0 +1,102 @@
+
+describe('nunjucks filters', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.filters = require('~/config/nunjucks/filters')
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  describe('#highlight', () => {
+    it('should render string with highlight', () => {
+      const searchTerm = 'example term'
+      const mockString = `we should see ${searchTerm} highlighted here`
+
+      const highlightedString = this.filters.highlight(mockString, searchTerm)
+
+      expect(highlightedString.val).to.equal(`we should see <span class="results-highlight">${searchTerm}</span> highlighted here`)
+    })
+
+    it('should render string without highlight', () => {
+      const searchTerm = 'example term'
+      const mockString = `we should not see another term highlighted here`
+
+      const highlightedString = this.filters.highlight(mockString, searchTerm)
+
+      expect(highlightedString.val).to.equal(mockString)
+    })
+  })
+
+  describe('#removeFalsey', () => {
+    it('should remove falsey values from array', () => {
+      const mockArrayWithFalsies = [
+        0,
+        null,
+        undefined,
+        '',
+        'example value',
+        false,
+        'another example value',
+      ]
+
+      const arrayWithoutFalsies = this.filters.removeFalsey(mockArrayWithFalsies)
+
+      expect(arrayWithoutFalsies).to.deep.equal([
+        'example value',
+        'another example value',
+      ])
+    })
+  })
+
+  describe('#pluralise', () => {
+    it('should return pluralised string when count is 0', () => {
+      const singularString = 'result'
+
+      const pluralisedString = this.filters.pluralise(singularString, 0)
+
+      expect(pluralisedString).to.equal(`${singularString}s`)
+    })
+
+    it('should return singular string string when count is 1', () => {
+      const singularString = 'result'
+
+      const pluralisedString = this.filters.pluralise(singularString, 1)
+
+      expect(pluralisedString).to.equal(singularString)
+    })
+
+    it('should return pluralised custom string when count is 0', () => {
+      const singularString = 'company'
+      const customPluralisedString = 'companies'
+
+      const pluralisedString = this.filters.pluralise(singularString, 0, customPluralisedString)
+
+      expect(pluralisedString).to.equal(customPluralisedString)
+    })
+
+    it('should return singular custom string when count is 1', () => {
+      const singularString = 'company'
+      const customPluralisedString = 'companies'
+
+      const pluralisedString = this.filters.pluralise(singularString, 1, customPluralisedString)
+
+      expect(pluralisedString).to.equal(singularString)
+    })
+  })
+
+  describe('#formatNumber', () => {
+    it('should correctly format number for "en-GB" locale', () => {
+      const formattedNumber = this.filters.formatNumber(12345678)
+
+      expect(formattedNumber).to.equal('12,345,678')
+    })
+
+    it('should correctly format number for "de-DE" locale', () => {
+      const formattedNumber = this.filters.formatNumber(12345678, 'de-DE')
+
+      expect(formattedNumber).to.equal('12,345,678')
+    })
+  })
+})

--- a/test/controllers/search.controller.test.js
+++ b/test/controllers/search.controller.test.js
@@ -181,18 +181,20 @@ describe('Search Controller', () => {
 
   describe('searchAction method', () => {
     const searchTerm = 'mock'
-    const expectedSearchEntityResultsData = [
-      {
-        count: 3,
-        entity: 'company',
-        text: 'Companies',
-      },
-      {
-        count: 1,
-        entity: 'contact',
-        text: 'Contacts',
-      },
-    ]
+    const expectedSearchEntityResultsData = (companyCount = 3, contactCount = 1) => {
+      return [
+        {
+          count: companyCount,
+          entity: 'company',
+          text: 'Companies',
+        },
+        {
+          count: contactCount,
+          entity: 'contact',
+          text: 'Contacts',
+        },
+      ]
+    }
 
     describe('when called with "company" searchType', () => {
       const companyResponse = require('~/test/data/search/company')
@@ -232,7 +234,7 @@ describe('Search Controller', () => {
                 expect(template).to.equal(`search/results-${searchType}`)
                 expect(data.searchTerm).to.equal(searchTerm)
                 expect(data.searchType).to.equal(searchType)
-                expect(data.searchEntityResultsData).to.deep.equal(expectedSearchEntityResultsData)
+                expect(data.searchEntityResultsData).to.deep.equal(expectedSearchEntityResultsData(0))
                 expect(data.results).to.deep.equal(expectedResults)
                 expect(data.pagination).to.be.a('array')
                 expect(data.pagination.length).to.equal(0)
@@ -283,7 +285,7 @@ describe('Search Controller', () => {
                 expect(template).to.equal(`search/results-${searchType}`)
                 expect(data.searchTerm).to.equal(searchTerm)
                 expect(data.searchType).to.equal(searchType)
-                expect(data.searchEntityResultsData).to.deep.equal(expectedSearchEntityResultsData)
+                expect(data.searchEntityResultsData).to.deep.equal(expectedSearchEntityResultsData())
                 expect(data.results).to.deep.equal(expectedResults)
                 expect(data.pagination).to.be.a('array')
                 expect(data.pagination.length).to.equal(0)

--- a/test/data/search/company.json
+++ b/test/data/search/company.json
@@ -1,10 +1,6 @@
 {
   "aggregations": [
     {
-      "count": 3,
-      "entity": "company"
-    },
-    {
       "count": 1,
       "entity": "contact"
     }


### PR DESCRIPTION
This work:
- adds default `result.aggregations` if they have not been provided by the api
- adds number formatting for the count results
- adds filter tests

![searchtweaks](https://cloud.githubusercontent.com/assets/2305016/26792656/06a57d9a-4a13-11e7-8976-c0377fa4e8b5.gif)



