### PR TITLE
Foreign search set to wrong value

### DIFF
--- a/src/services/search.service.js
+++ b/src/services/search.service.js
@@ -36,7 +36,7 @@ function searchForeignCompany ({ token, searchTerm, page = 1, limit = 10 }) {
   }
   const body = {
     original_query: searchTerm,
-    uk_based: true,
+    uk_based: false,
   }
   const options = {
     url: `${config.apiRoot}/v3/search/company${buildQueryString(queryParams)}`,


### PR DESCRIPTION
Foreign search method should set `uk_based` to `false` instead of
`true`. It currently returns only UK based companies instead of
foreign based companies.