### PR TITLE
fix for add company search

### DIFF
--- a/src/controllers/investment/start.controller.js
+++ b/src/controllers/investment/start.controller.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 
 const { getInflatedDitCompany } = require('../../services/company.service')
 const { getCompanyInvestmentProjects } = require('../../repos/investment.repo')
-const { searchForeignCompany } = require('../../services/search.service')
+const { searchForeignCompanies } = require('../../services/search.service')
 const { getPagination } = require('../../lib/pagination')
 
 function getHandler (req, res, next) {
@@ -19,7 +19,7 @@ function getHandler (req, res, next) {
   }
 
   if (searchTerm) {
-    promises.push(searchForeignCompany({
+    promises.push(searchForeignCompanies({
       token: req.session.token,
       page: req.query.page,
       searchTerm,

--- a/src/controllers/search.controller.js
+++ b/src/controllers/search.controller.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const companyRepository = require('../repos/company.repo')
 const { buildCompanyUrl } = require('../services/company.service')
-const searchService = require('../services/search.service')
+const { search } = require('../services/search.service')
 const getPagination = require('../lib/pagination').getPagination
 const Q = require('q')
 const Joi = require('joi')
@@ -57,7 +57,7 @@ function searchAction (req, res, next) {
   const searchType = req.params.searchType
   const searchTerm = req.query.term
 
-  searchService.search({
+  search({
     token: req.session.token,
     searchTerm,
     searchType,

--- a/src/services/company.service.js
+++ b/src/services/company.service.js
@@ -73,30 +73,6 @@ function getInflatedDitCompany (token, id) {
   })
 }
 
-function getCompanyForSource (token, id, source) {
-  return new Promise((resolve, reject) => {
-    Q.spawn(function * () {
-      try {
-        if (source === 'company_companieshousecompany') {
-          const companies_house_data = yield companyRepository.getCHCompany(token, id)
-          resolve({
-            company_number: id,
-            companies_house_data,
-            contacts: [],
-            interactions: [],
-          })
-          return
-        }
-
-        const company = yield getInflatedDitCompany(token, id)
-        resolve(company)
-      } catch (error) {
-        reject(error)
-      }
-    })
-  })
-}
-
 /**
  * Pass an API formatted company record in and return a path to view that company depending on company type
  *
@@ -151,4 +127,9 @@ function getCommonTitlesAndlinks (req, res, company) {
   res.locals.companyUrl = buildCompanyUrl(company)
 }
 
-module.exports = { getInflatedDitCompany, getCompanyForSource, buildCompanyUrl, getCommonTitlesAndlinks, getHeadingAddress }
+module.exports = {
+  getInflatedDitCompany,
+  buildCompanyUrl,
+  getCommonTitlesAndlinks,
+  getHeadingAddress,
+}

--- a/src/services/search.service.js
+++ b/src/services/search.service.js
@@ -1,5 +1,3 @@
-const Q = require('q')
-const winston = require('winston')
 const authorisedRequest = require('../lib/authorised-request')
 const config = require('../config')
 const { buildQueryString } = require('../lib/url-helpers')
@@ -25,18 +23,15 @@ function search ({ token, searchTerm, searchType, limit = 10, page = 1 }) {
     })
 }
 
-// TODO discuss why this needs to be a POST rather than a GET like the default `/v3/search`
-// TODO this work has been abstracted for easy removal of code once this api call has has been changed to GET
-// TODO we have query params on a POST's url
-// TODO we have a param named `original_query` that is set to `term` on the backend, this needs aligning to other endpoints and changed to `term` in the request
-function searchForeignCompany ({ token, searchTerm, page = 1, limit = 10 }) {
+// TODO the search endpoints need aligning see Jira DH-293 for details
+function searchCompanies ({ token, searchTerm, isUkBased, page = 1, limit = 10 }) {
   const queryParams = {
     offset: (page * limit) - limit,
     limit,
   }
   const body = {
     original_query: searchTerm,
-    uk_based: false,
+    uk_based: isUkBased,
   }
   const options = {
     url: `${config.apiRoot}/v3/search/company${buildQueryString(queryParams)}`,
@@ -52,57 +47,33 @@ function searchForeignCompany ({ token, searchTerm, page = 1, limit = 10 }) {
     })
 }
 
-function suggestCompany (token, term, types) {
-  if (!types) {
-    types = ['company_company']
-  }
-  const options = {
-    url: `${config.apiRoot}/search/`,
-    body: {
-      term,
-      doc_type: types,
-      limit: 10,
-      offset: 0,
-    },
-    method: 'POST',
-  }
+function searchForeignCompanies (options) {
+  const optionsUkBasedFalse = Object.assign({}, options, { uk_based: false })
 
-  return authorisedRequest(token, options)
-    .then((result) => {
-      winston.debug('suggestion raw result', result)
-      return result.hits
-        .map((hit) => ({
-          name: hit._source.name,
-          id: hit._id,
-          _type: hit._type,
-        }))
-    })
-    .catch((error) => {
-      winston.error('Error calling auth reguest for suggestions', error)
-    })
+  return searchCompanies(optionsUkBasedFalse)
 }
 
-function searchLimited (token, term) {
-  return new Promise((resolve, reject) => {
-    Q.spawn(function * () {
-      try {
-        const allResults = yield search({ token, term, filters: ['company_company', 'company_companieshousecompany'] })
-        const filtered = allResults.hits.filter(result => (result._type === 'company_companieshousecompany' ||
-          (result._source.business_type && result._source.business_type.toLowerCase() === 'private limited company') ||
-          (result._source.business_type && result._source.business_type.toLowerCase() === 'public limited company')))
+function searchLimitedCompanies (options) {
+  const optionsUkBasedTrue = Object.assign({}, options, { isUkBased: true })
 
-        resolve(filtered)
-      } catch (error) {
-        winston.error(error)
-        reject(error)
+  return searchCompanies(optionsUkBasedTrue)
+    .then((result) => {
+      const limitedCompanies = result.results.filter((company) => {
+        return company.company_number ||
+          (company.business_type && company.business_type.name.toLowerCase().includes('limited company'))
+      })
+
+      return {
+        page: result.page,
+        results: limitedCompanies,
+        count: result.count,
       }
     })
-  })
 }
 
 module.exports = {
   search,
-  searchForeignCompany,
-  suggestCompany,
-  searchLimited,
+  searchCompanies,
+  searchLimitedCompanies,
+  searchForeignCompanies,
 }

--- a/src/views/company/add-step-2.njk
+++ b/src/views/company/add-step-2.njk
@@ -10,12 +10,12 @@
     <div id="business-type" class="key-value__key form-label-bold">Business type
       <a href="/company/add-step-1" class="button-link">Change</a>
     </div>
-    <div class="key-value__value" aria-labelledby="business-type">{{companyTypeOptions[business_type]}}</div>
+    <div class="key-value__value" aria-labelledby="business-type">{{ companyTypeOptions[businessType] }}</div>
   </div>
 
   <form class="searchbar searchbar--show-label" action="/company/add-step-2/" method="get" role="search">
-    <input type="hidden" name="business_type" value="{{business_type}}">
-    <input type="hidden" name="country" value="{{country}}">
+    <input type="hidden" name="business_type" value="{{ businessType }}">
+    <input type="hidden" name="country" value="{{ country }}">
 
     <div class="form-group">
       <label class="form-label-bold" for="search-term">
@@ -23,35 +23,54 @@
         <span class="form-hint">Search for the registered company name, company number or address</span>
       </label>
       <div class="searchbar__wrapper">
-        <input class="searchbar__input form-control" id="search-term" type="search" name="term" value="{{query.term}}" placeholder="Search for company">
+        <input class="searchbar__input form-control" id="search-term" type="search" name="term" value="{{ searchTerm }}" placeholder="Search for company">
         <input class="searchbar__submit" type="submit" value="Search">
       </div>
     </div>
   </form>
 
-  {% if hits %}
+  {% if companies %}
     <ol class="results-list result-list--expandable">
-      {% for hit in hits %}
+      {% for company in companies %}
         <li class="results-list__result">
-          {% if hit.selected %}
-            <a class="open" href="{{closeLink}}">
-              <h3 class="result-title">{{hit.name}}</h3>
+          {% set isSelected = currentlySelected and (company.id == currentlySelected or company.company_number == currentlySelected) %}
+
+          {% if isSelected %}
+            <a class="open" href="/company/add-step-2/?term={{ searchTerm }}&business_type={{ businessType }}&country={{ country }}">
+              <h3 class="result-title">{{company.name}}</h3>
             </a>
           {% else %}
-            <a class="closed" href="{{hit.url}}">
-              <h3 class="result-title">{{hit.name}}</h3>
+            <a class="closed" href="/company/add-step-2/?term={{ searchTerm }}&business_type={{ businessType }}&country={{ country }}&selected={{ company.company_number if company.company_number else company.id }}">
+              <h3 class="result-title">{{ company.name }}</h3>
             </a>
           {% endif %}
-          {% if hit.selected and chDetails %}
+
+          {% if isSelected %}
             <div class="panel panel-border-wide">
-              {{ trade.keyvaluetable(
-                chDetails,
-                labels=chDetailsLabels,
-                keyorder=chDetailsDisplayOrder,
-                class="table--small"
-              ) }}
-              <div class="table_footnote">Data from <strong>Companies House</strong></div>
-              <a class="button" href="{{addLink.url}}">{{addLink.label}}</a>
+                {{ trade.keyvaluetable(
+                  displayDetails,
+                  labels=labels,
+                  keyorder=[
+                    'business_type',
+                    'company_status',
+                    'incorporation_date',
+                    'sic_code'
+                  ],
+                  class="table--small"
+                ) }}
+
+                {% if company.company_number %}
+                  {% set href = '/company/add/ltd/' + company.company_number %}
+                  {% set label = 'Choose company' %}
+                {% else %}
+                  {% set href = '/company/edit/ltd/' + company.id %}
+                  {% set label = 'Go to company record' %}
+                {% endif %}
+
+                {% if company.company_number %}
+                  <div class="table_footnote">Data from <strong>Companies House</strong></div>
+                {% endif %}
+                <a class="button" href="{{ href }}">{{ label }}</a>
             </div>
           {% endif %}
         </li>
@@ -62,5 +81,10 @@
       if you can't find the company you're looking for, try a different search term. check
       the company's website or any email correspondence that contains company registration details
     </p>
+
+    {% component 'pagination', {
+      pages: pagination
+    } %}
+
   {% endif %}
 {% endblock %}

--- a/test/controllers/investment/start.controller.test.js
+++ b/test/controllers/investment/start.controller.test.js
@@ -24,7 +24,7 @@ describe('Investment start controller', () => {
     this.next = this.sandbox.stub()
     this.getInflatedDitCompany = this.sandbox.stub().resolves(ukCompany)
     this.getCompanyInvestmentProjects = this.sandbox.stub().resolves(investmentProjects)
-    this.searchForeignCompany = this.sandbox.stub().resolves(searchResults)
+    this.searchForeignCompanies = this.sandbox.stub().resolves(searchResults)
     this.getPagination = this.sandbox.stub().resolves({})
 
     this.controller = proxyquire('~/src/controllers/investment/start.controller', {
@@ -35,7 +35,7 @@ describe('Investment start controller', () => {
         getCompanyInvestmentProjects: this.getCompanyInvestmentProjects,
       },
       '../../services/search.service': {
-        searchForeignCompany: this.searchForeignCompany,
+        searchForeignCompanies: this.searchForeignCompanies,
       },
       '../../lib/pagination': {
         getPagination: this.getPagination,

--- a/test/data/company/companiesHouseCompany.json
+++ b/test/data/company/companiesHouseCompany.json
@@ -1,0 +1,26 @@
+{
+  "id": 689998,
+  "created_on": null,
+  "modified_on": null,
+  "name": "EXAMPLE LTD",
+  "registered_address_1": "PEARL ASSURANCE HOUSE",
+  "registered_address_2": "319 EXAMPLE LANE",
+  "registered_address_3": null,
+  "registered_address_4": null,
+  "registered_address_town": "LONDON",
+  "registered_address_county": "",
+  "registered_address_postcode": "N12 8LY",
+  "company_number": "06960817",
+  "company_category": "Private Limited Company",
+  "company_status": "Liquidation",
+  "sic_code_1": "82990 - Other business support service activities n.e.c.",
+  "sic_code_2": "",
+  "sic_code_3": "",
+  "sic_code_4": "",
+  "uri": "http://business.data.gov.uk/id/company/00000817",
+  "incorporation_date": "2009-07-13",
+  "registered_address_country": {
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+    "name": "United Kingdom"
+  }
+}

--- a/test/data/company/displayCompaniesHouse.json
+++ b/test/data/company/displayCompaniesHouse.json
@@ -1,0 +1,11 @@
+{
+  "name": "Cathy S Limited",
+  "company_number": "06960817",
+  "business_type": "Private Limited Company",
+  "company_status": "Liquidation",
+  "registered_address": "Pearl Assurance House, 319 Ballards Lane, London, N12 8LY, United Kingdom",
+  "incorporation_date": "13 July 2009",
+  "sic_code": [
+    "82990 - Other business support service activities n.e.c."
+  ]
+}

--- a/test/data/search/companiesHouseAndLtdCompanies.json
+++ b/test/data/search/companiesHouseAndLtdCompanies.json
@@ -1,0 +1,205 @@
+{
+  "count": 3,
+  "results": [
+    {
+      "companies_house_data": {
+        "id": "170494",
+        "company_number": "08311441"
+      },
+      "business_type": {
+        "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
+        "name": "Private limited company"
+      },
+      "classification": {
+        "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
+        "name": "Undefined"
+      },
+      "registered_address_country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+      "sector": {
+        "id": "bb22c9d2-5f95-e211-a939-e4115bead28a",
+        "name": "Automotive : Component Manufacturing : Electronic Components"
+      },
+      "uk_region": {
+        "id": "924cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Jersey"
+      },
+      "contacts": [],
+      "id": "3f3f6f87-4645-409e-8957-b97a0f306911",
+      "uk_based": true,
+      "export_to_countries": [],
+      "future_interest_countries": [],
+      "created_on": "2017-05-04T15:25:25.020751",
+      "modified_on": "2017-05-04T15:25:25.020751",
+      "archived": false,
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "name": "ACHME LIMITED",
+      "registered_address_1": "FIRST FLOOR ACHME HOUSE",
+      "registered_address_2": "ACHME ROAD",
+      "registered_address_3": null,
+      "registered_address_4": null,
+      "registered_address_town": "ACHME",
+      "registered_address_county": "ACHME",
+      "registered_address_postcode": "E15 1HP",
+      "company_number": "08311441",
+      "alias": null,
+      "employee_range": null,
+      "turnover_range": null,
+      "account_manager": null,
+      "lead": false,
+      "description": "test\r\n\r\ntest\r\n\r\ntst",
+      "website": null,
+      "trading_address_1": null,
+      "trading_address_2": null,
+      "trading_address_3": null,
+      "trading_address_4": null,
+      "trading_address_town": null,
+      "trading_address_county": null,
+      "trading_address_country": null,
+      "trading_address_postcode": null,
+      "headquarter_type": null,
+      "parent": null,
+      "one_list_account_owner": null,
+      "level": 0
+    },
+    {
+      "business_type": {
+        "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
+        "name": "Private limited company"
+      },
+      "classification": {
+        "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
+        "name": "Undefined"
+      },
+      "employee_range": {
+        "id": "3fafd8d0-5d95-e211-a939-e4115bead28a",
+        "name": "50 to 249"
+      },
+      "registered_address_country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+      "sector": {
+        "id": "bb22c9d2-5f95-e211-a939-e4115bead28a",
+        "name": "Automotive : Component Manufacturing : Electronic Components"
+      },
+      "turnover_range": {
+        "id": "7a4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "£33.5M+"
+      },
+      "uk_region": {
+        "id": "924cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Jersey"
+      },
+      "contacts": [],
+      "id": "d4f18091-5457-4cde-b482-177a425e4987",
+      "uk_based": true,
+      "export_to_countries": [],
+      "future_interest_countries": [],
+      "created_on": "2017-05-04T15:33:29.342852",
+      "modified_on": "2017-05-04T15:33:29.342852",
+      "archived": false,
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "name": "Bouncing ball LTD",
+      "registered_address_1": "FIRST FLOOR Bouncing ball HOUSE",
+      "registered_address_2": "Bouncing ball ROAD",
+      "registered_address_3": null,
+      "registered_address_4": null,
+      "registered_address_town": "Bouncing ball",
+      "registered_address_county": "LONDON",
+      "registered_address_postcode": "GH7 1HP",
+      "company_number": null,
+      "alias": null,
+      "account_manager": null,
+      "lead": false,
+      "description": "test\r\n\r\ntest\r\n\r\ntest",
+      "website": "http://moo.com",
+      "trading_address_1": null,
+      "trading_address_2": null,
+      "trading_address_3": null,
+      "trading_address_4": null,
+      "trading_address_town": null,
+      "trading_address_county": null,
+      "trading_address_country": null,
+      "trading_address_postcode": null,
+      "headquarter_type": null,
+      "parent": null,
+      "one_list_account_owner": null,
+      "level": 0
+    },
+    {
+      "business_type": {
+        "id": "6f75408b-03e7-e611-bca1-e4115bead28a",
+        "name": "Public Limited Company"
+      },
+      "classification": {
+        "id": "0167b456-0ddd-49bd-8184-e3227a0b6396",
+        "name": "Undefined"
+      },
+      "employee_range": {
+        "id": "3fafd8d0-5d95-e211-a939-e4115bead28a",
+        "name": "50 to 249"
+      },
+      "registered_address_country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+      "sector": {
+        "id": "bb22c9d2-5f95-e211-a939-e4115bead28a",
+        "name": "Automotive : Component Manufacturing : Electronic Components"
+      },
+      "turnover_range": {
+        "id": "7a4cd12a-6095-e211-a939-e4115bead28a",
+        "name": "£33.5M+"
+      },
+      "uk_region": {
+        "id": "924cd12a-6095-e211-a939-e4115bead28a",
+        "name": "Jersey"
+      },
+      "contacts": [],
+      "id": "0fb87119-da4d-411f-b4d8-56574f9bb150",
+      "uk_based": true,
+      "export_to_countries": [],
+      "future_interest_countries": [],
+      "created_on": "2017-05-04T15:25:39.025613",
+      "modified_on": "2017-05-04T15:25:39.025613",
+      "archived": false,
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "name": "Hats R Us",
+      "registered_address_1": "FIRST FLOOR Hats R Us HOUSE",
+      "registered_address_2": "Hats R Us ROAD",
+      "registered_address_3": null,
+      "registered_address_4": null,
+      "registered_address_town": "Hats R Us",
+      "registered_address_county": "Hats R Us Ville",
+      "registered_address_postcode": "io8 1HP",
+      "company_number": null,
+      "alias": null,
+      "account_manager": null,
+      "lead": false,
+      "description": "test\r\n\r\ntest\r\n\r\ntest",
+      "website": null,
+      "trading_address_1": null,
+      "trading_address_2": null,
+      "trading_address_3": null,
+      "trading_address_4": null,
+      "trading_address_town": null,
+      "trading_address_county": null,
+      "trading_address_country": null,
+      "trading_address_postcode": null,
+      "headquarter_type": null,
+      "parent": null,
+      "one_list_account_owner": null,
+      "level": 0
+    }
+  ],
+  "page": 1
+}

--- a/test/services/search.service.test.js
+++ b/test/services/search.service.test.js
@@ -1,6 +1,6 @@
 const nock = require('nock')
 const config = require('~/src/config')
-const searchService = require('~/src/services/search.service')
+const { search } = require('~/src/services/search.service')
 
 describe('Search service', function () {
   describe('searchService.search method', function () {
@@ -25,7 +25,7 @@ describe('Search service', function () {
         })
         .reply(200, mockResponse)
 
-      searchService.search({
+      search({
         token: 'token',
         searchTerm,
         searchType,


### PR DESCRIPTION
This work involves:
- updating the search used on `/company/add-step-2/` to work with the new search api.
- adding markup to display `Private/Limited` companies
- updating tests and adding test data fixtures

### Of Note
- I have moved a portion of the simple logic into the template away from the controller
- There are parts of this code that I am not happy with and need to be addressed at a future point.
In particular the tests are just testing that methods have been called and could do with a refactor
- I would like to approach this in a `middleware` fashion similar to work from @tyom 


![add-company](https://user-images.githubusercontent.com/2305016/26886449-4e7e700a-4b9d-11e7-8ba6-2f6fb321c17a.gif)
