### PR TITLE
Allow objects to be filtered by removeFalsey filter

### DIFF
--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -2,9 +2,14 @@ const nunjucks = require('nunjucks')
 const {
   isArray,
   isPlainObject,
+  isEmpty,
   pickBy,
   isNil,
 } = require('lodash')
+
+function isNotEmpty (value) {
+  return !isNil(value) && !/^\s*$/.test(value) && !(isPlainObject(value) && isEmpty(value))
+}
 
 const filters = {
   stringify: JSON.stringify,
@@ -17,12 +22,12 @@ const filters = {
     )
   },
 
-  removeFalsey: (collection) => {
+  removeNilAndEmpty: (collection) => {
     if (isArray(collection)) {
-      return collection.filter(item => item)
+      return collection.filter(isNotEmpty)
     }
     if (isPlainObject(collection)) {
-      return pickBy(collection, (value) => !isNil(value) && !/^\s*$/.test(value))
+      return pickBy(collection, isNotEmpty)
     }
     return collection
   },

--- a/config/nunjucks/filters.js
+++ b/config/nunjucks/filters.js
@@ -1,4 +1,11 @@
 const nunjucks = require('nunjucks')
+const {
+  isArray,
+  isPlainObject,
+  pickBy,
+  isNil,
+} = require('lodash')
+
 const filters = {
   stringify: JSON.stringify,
 
@@ -10,8 +17,14 @@ const filters = {
     )
   },
 
-  removeFalsey: (array) => {
-    return array.filter(item => item)
+  removeFalsey: (collection) => {
+    if (isArray(collection)) {
+      return collection.filter(item => item)
+    }
+    if (isPlainObject(collection)) {
+      return pickBy(collection, (value) => !isNil(value) && !/^\s*$/.test(value))
+    }
+    return collection
   },
 
   pluralise: (string, count, pluralisedWord) => {

--- a/src/views/_macros/address.njk
+++ b/src/views/_macros/address.njk
@@ -12,7 +12,7 @@
  #   ]) }}
  #}
 {% macro addressFormatter(addressDetails, searchTerm) %}
-  {%- for addressDetail in addressDetails | removeFalsey -%}
+  {%- for addressDetail in addressDetails | removeNilAndEmpty -%}
 
     {% if addressDetail %}
       {{ addressDetail | highlight(searchTerm) -}}

--- a/test/config/nunjucks/filters.test.js
+++ b/test/config/nunjucks/filters.test.js
@@ -40,6 +40,27 @@ describe('nunjucks filters', () => {
         'another example value',
       ])
     })
+
+    it('should remove falsey values from object', () => {
+      const mockObjectWithFalsies = {
+        a: true,
+        b: null,
+        c: undefined,
+        d: 'false',
+        e: 'value',
+        f: '',
+        g: false,
+      }
+
+      const objectWithoutFalsies = filters.removeFalsey(mockObjectWithFalsies)
+
+      expect(objectWithoutFalsies).to.deep.equal({
+        a: true,
+        d: 'false',
+        e: 'value',
+        g: false,
+      })
+    })
   })
 
   describe('#pluralise', () => {

--- a/test/config/nunjucks/filters.test.js
+++ b/test/config/nunjucks/filters.test.js
@@ -21,9 +21,9 @@ describe('nunjucks filters', () => {
     })
   })
 
-  describe('#removeFalsey', () => {
-    it('should remove falsey values from array', () => {
-      const mockArrayWithFalsies = [
+  describe('#removeNilAndEmpty', () => {
+    it('should remove nil and empty values from array', () => {
+      const mockArrayWithEmpties = [
         0,
         null,
         undefined,
@@ -33,16 +33,18 @@ describe('nunjucks filters', () => {
         'another example value',
       ]
 
-      const arrayWithoutFalsies = filters.removeFalsey(mockArrayWithFalsies)
+      const actual = filters.removeNilAndEmpty(mockArrayWithEmpties)
 
-      expect(arrayWithoutFalsies).to.deep.equal([
+      expect(actual).to.deep.equal([
+        0,
         'example value',
+        false,
         'another example value',
       ])
     })
 
-    it('should remove falsey values from object', () => {
-      const mockObjectWithFalsies = {
+    it('should remove nil and empty values from object', () => {
+      const mockObjectWithEmpties = {
         a: true,
         b: null,
         c: undefined,
@@ -50,11 +52,13 @@ describe('nunjucks filters', () => {
         e: 'value',
         f: '',
         g: false,
+        h: [],
+        i: {},
       }
 
-      const objectWithoutFalsies = filters.removeFalsey(mockObjectWithFalsies)
+      const actual = filters.removeNilAndEmpty(mockObjectWithEmpties)
 
-      expect(objectWithoutFalsies).to.deep.equal({
+      expect(actual).to.deep.equal({
         a: true,
         d: 'false',
         e: 'value',


### PR DESCRIPTION
Nunjucks allows to use `length` filter to check if object is empty. This allows us to check objects have values before passing them to components. If objects has `undefined` or `null` values it might be considered not worthy of showing. Allowing to filter out those values gives ability to only show values that are explicitly set.

```njk
{% set obj = { a: null, b: undefined, c: 'value', d: false, e: '' } %}
{% set arr = [null, undefined, 'value', false, ''] %}

{% if obj | removeFalsey | length %}
  {{ obj | dump }} {# { c: 'value', d: false } #}
{% endif %}
{{ arr | dump }} {# [ 'value', false ] #}
```