### PR TITLE
Ensure login view uses correct layout

### DIFF
--- a/src/views/login.njk
+++ b/src/views/login.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/_base.njk" %}
+{% extends "_layouts/datahub-base.njk" %}
 {% import "macros/trade.html" as trade %}
 
 {% block body_main_header_content %}{% endblock %}


### PR DESCRIPTION
The login view was using the old name for the datahub base layout.

This makes sure it uses the correct one.