### PR TITLE
Use POST to unarchive contacts and companies when calling the back end

### DIFF
--- a/src/repos/company.repo.js
+++ b/src/repos/company.repo.js
@@ -62,7 +62,10 @@ function archiveCompany (token, companyId, reason) {
 }
 
 function unarchiveCompany (token, companyId) {
-  return authorisedRequest(token, `${config.apiRoot}/company/${companyId}/unarchive/`)
+  return authorisedRequest(token, {
+    method: 'POST',
+    url: `${config.apiRoot}/company/${companyId}/unarchive/`,
+  })
 }
 
 module.exports = {

--- a/src/repos/contact.repo.js
+++ b/src/repos/contact.repo.js
@@ -35,7 +35,10 @@ function archiveContact (token, contactId, reason) {
 }
 
 function unarchiveContact (token, contactId) {
-  return authorisedRequest(token, `${config.apiRoot}/v3/contact/${contactId}/unarchive`)
+  return authorisedRequest(token, {
+    method: 'POST',
+    url: `${config.apiRoot}/v3/contact/${contactId}/unarchive`,
+  })
 }
 
 function getContactsForCompany (token, companyId) {


### PR DESCRIPTION
GET for unarchiving is being removed from the back end in favour of POST.