### PR TITLE
Layout updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ To start the server just:
 
     docker-compose up
 
-The server starts in developer mode, which means that when you make local changes it will auto-compile 
-sass or javavscript, and will restart nodejs when server side changes are made. A container with redis will also start, this is linked to the data hub container. 
+The server starts in developer mode, which means that when you make local changes it will auto-compile
+sass or javavscript, and will restart nodejs when server side changes are made. A container with redis will also start, this is linked to the data hub container.
 
 You can access the server on port 3000, [http://localhost:3000](http://localhost:3000). You can also run
 a remote debug session over port 5858 if using webstorm/Intellij or Visual Studio Code
 
 #### Environment Variables
-Docker Compose [supports declaring default environment variables](https://docs.docker.com/compose/environment-variables/#the-envfile-configuration-option) in an environment file. If you wish to send through environment variables to the docker containers please add them into the `.env` file in the projects root. 
+Docker Compose [supports declaring default environment variables](https://docs.docker.com/compose/environment-variables/#the-envfile-configuration-option) in an environment file. If you wish to send through environment variables to the docker containers please add them into the `.env` file in the projects root.
 
 ### Native install
 
@@ -161,7 +161,7 @@ res.render('some-page', {
 })
 ```
 ```njk
-{% component 'person', personData, gender='male' %} 
+{% component 'person', personData, gender='male' %}
 ```
 
 Is the same as:
@@ -178,7 +178,7 @@ Is the same as:
 
 Templates use Nunjuck's [template inheritance](https://mozilla.github.io/nunjucks/templating.html#template-inheritance).
 There are several top level blocks which are used for injecting content during rendering. Each subsequent template
-that extends the base layout can include these additional blocks. 
+that extends the base layout can include these additional blocks.
 
 ### Nunjucks base template blocks
 
@@ -195,10 +195,9 @@ to completely override everything inside `head` element if needed or just the se
   - `body_notifications` - wraps cookie message container (above site_header, after skiplinks)
   - `body_site_header` - wraps site header
     - `header_site_title` - wraps the site title
-    - `header_service_title` - wraps the service title
+    - `header_menu` - wraps the header menu
   - `body_main` - wraps the main content block
     - `body_main_header` - contains the header of the main block
-    - `body_main_header_content` - contains the heading of the main block
     - `body_main_content` - contains main content (inside main#content)
   - `body_footer` - wraps site footer container (inside body > footer)
   - `body_footer_content` - contains content inside site footer
@@ -209,6 +208,7 @@ Base layout checks for certain variables.
 
 - `siteTitle` {string} - name of the site. Defaults to 'Department for International Trade'.
 - `serviceTitle` {string} - name of the service.
+- `phaseBanner` {boolean} - whether to show the separate phase banner or default to phase tag in the global header. Possible values: `true` and `false`.
 - `projectPhase` {string} - phase of the project. Possible values: `alpha` and `beta`.
 
 ### Template inheritance diagram

--- a/config/nunjucks/globals.js
+++ b/config/nunjucks/globals.js
@@ -1,5 +1,6 @@
 module.exports = {
-  siteTitle: 'Data Hub',
-  projectPhase: 'beta',
+  siteTitle: 'DIT',
+  serviceTitle: 'Data Hub',
+  projectPhase: 'alpha',
   feedbackLink: '/support/bug',
 }

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -14,6 +14,7 @@ module.exports = function locals (req, res, next) {
   res.locals.env = config.env
   res.locals.googleTagManagerKey = config.googleTagManagerKey
   res.locals.query = req.query
+  res.locals.currentPath = req.path
   winston.debug('locals:end')
   next()
 }

--- a/src/sass/_components.scss
+++ b/src/sass/_components.scss
@@ -1,8 +1,9 @@
 @import "components/action-bar";
 @import "components/data-table";
 @import "components/local-nav";
-@import "components/pagination-nav";
 @import "components/metadata-list";
+@import "components/pagination-nav";
+@import "components/phase-badge";
 @import "components/results-summary";
 @import "components/results-list";
 @import "components/search-bar";

--- a/src/sass/_components.scss
+++ b/src/sass/_components.scss
@@ -4,6 +4,7 @@
 @import "components/metadata-list";
 @import "components/pagination-nav";
 @import "components/phase-badge";
+@import "components/proposition-menu";
 @import "components/results-summary";
 @import "components/results-list";
 @import "components/search-bar";

--- a/src/sass/components/_phase-badge.scss
+++ b/src/sass/components/_phase-badge.scss
@@ -1,0 +1,22 @@
+@import "../settings/colours";
+@import "../settings/layout";
+@import "../tools/mixins/conditionals";
+
+// TODO: remove qualifier
+span.phase-badge {
+  @include bold-font(14);
+  background-color: $govuk-blue;
+  color: $white;
+  cursor: default;
+  display: inline-block;
+  font-weight: 600;
+  letter-spacing: 1px;
+  line-height: 1;
+  margin: 0 ($default-spacing-unit / 2) 0 0;
+  padding: 3px 5px;
+  vertical-align: top;
+
+  @include media(tablet) {
+    line-height: 1;
+  }
+}

--- a/src/sass/components/_proposition-menu.scss
+++ b/src/sass/components/_proposition-menu.scss
@@ -1,0 +1,61 @@
+@import "../settings/colours";
+@import "../settings/layout";
+@import "../tools/mixins/addons";
+@import "../tools/mixins/conditionals";
+@import "../tools/mixins/layout";
+
+.proposition-menu {
+  @include bold-font(14);
+  color: $white;
+  margin: 0;
+  padding: $baseline-grid-unit 0 0;
+
+  @include media(tablet) {
+    @include bold-font(16);
+    float: right;
+  }
+}
+
+.proposition-menu__item {
+  border-bottom: 1px solid $grey-1;
+  display: block;
+
+  @include media(tablet) {
+    border-bottom: 0;
+    float: left;
+    padding-left: $default-spacing-unit;
+
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+}
+
+.proposition-menu__link {
+  color: inherit;
+  display: block;
+  padding: $baseline-grid-unit;
+  text-decoration: none;
+
+  &:active,
+  &:visited,
+  &:hover {
+    color: inherit;
+  }
+
+  &:focus {
+    color: $black;
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  @include media(tablet) {
+    padding: 0;
+  }
+
+  &.is-active {
+    color: $light-blue;
+  }
+}

--- a/src/sass/objects/layout/_global-header.scss
+++ b/src/sass/objects/layout/_global-header.scss
@@ -8,38 +8,61 @@
 }
 
 .global-header__inner {
+  @include clearfix;
   @include site-width-container;
   padding: ($baseline-grid-unit * 3) 0;
 }
 
-.global-header__link {
+.global-header__site-title {
+  word-spacing: -4px;
+
+  @include media(tablet) {
+    float: left;
+  }
+
+  .phase-badge {
+    margin-top: 5px;
+  }
+}
+
+.global-header__logo {
+  border-bottom: 1px solid transparent;
   display: inline-block;
   color: inherit;
-  font-size: 1.6em;
-  font-weight: 600;
   text-decoration: none;
-  padding: 0 $baseline-grid-unit;
-  margin: 0 (-$baseline-grid-unit);
+  padding: 0;
+  margin: 0 $default-spacing-unit 0 0;
 
   &:hover,
   &:visited,
   &:focus {
-    text-decoration: underline;
     color: inherit;
     background-color: transparent;
+  }
+
+  &:hover {
+    border-color: inherit;
+  }
+}
+
+.global-header__site-name {
+  @include bold-font(36);
+  letter-spacing: 1px;
+  line-height: .9;
+
+  @include media(tablet) {
+    line-height: .9;
+    font-size: 30px;
   }
 }
 
 .global-header__service-name {
-  @include core-font(16);
-  color: $grey-1;
-  display: block;
-  margin-top: $baseline-grid-unit * 2;
+  @include core-font(24);
+  color: inherit;
+  line-height: .9;
+  margin-left: $baseline-grid-unit * 2;
 
   @include media(tablet) {
-    @include core-font(20);
-    display: inline;
-    margin-left: $baseline-grid-unit * 4;
-    margin-top: 0;
+    line-height: .9;
   }
 }

--- a/src/sass/objects/layout/_main-content.scss
+++ b/src/sass/objects/layout/_main-content.scss
@@ -11,6 +11,7 @@
 
 .main-content__inner {
   @include site-width-container;
+  border-top: 10px solid $govuk-blue;
   padding-bottom: $default-spacing-unit * 2;
 
   @include media(desktop) {

--- a/src/sass/objects/layout/_phase-banner.scss
+++ b/src/sass/objects/layout/_phase-banner.scss
@@ -11,22 +11,6 @@
 }
 
 // TODO: remove qualifier
-span.phase-banner__tag {
-  background-color: $govuk-blue;
-  display: inline-block;
-  padding: 3px 6px 2px;
-  font-weight: 600;
-  color: $white;
-  margin-right: .2em;
-  cursor: default;
-
-  @include media(tablet) {
-    padding-top: 2px;
-  }
-}
-
-// TODO: remove qualifier
 span.phase-banner__message {
-  padding-left: 5px;
-  width: 100%;
+  display: inline-block;
 }

--- a/src/views/_layouts/datahub-base.njk
+++ b/src/views/_layouts/datahub-base.njk
@@ -17,6 +17,35 @@
   {% endif %}
 {% endblock %}
 
+{% block header_menu %}
+  <nav>
+    <ul class="proposition-menu">
+      {% if user %}
+        <li class="proposition-menu__item">
+          <a href="/" class="proposition-menu__link{{ ' is-active' if currentPath == '/' }}">Dashboard</a>
+        </li>
+      {% endif %}
+      {% if feedbackLink %}
+        <li class="proposition-menu__item">
+          <a href="{{ feedbackLink }}" class="proposition-menu__link{{ ' is-active' if '/support' in currentPath }}">Support</a>
+        </li>
+      {% endif %}
+      {% if user %}
+        <li class="proposition-menu__item">
+          <a href="/myaccount" class="proposition-menu__link{{ ' is-active' if currentPath == '/myaccount' }}">{{ user.name }}</a>
+        </li>
+      {% endif %}
+      <li class="proposition-menu__item">
+        {% if user %}
+          <a href="/login/signout" class="proposition-menu__link">Sign out</a>
+        {% else %}
+          <a href="/login" class="proposition-menu__link">Sign in</a>
+        {% endif %}
+      </li>
+    </ul>
+  </nav>
+{% endblock %}
+
 {% block body %}
   {% include "_includes/google-tag-manager-no-script.njk" %}
   {{ super() }}

--- a/src/views/_layouts/datahub-base.njk
+++ b/src/views/_layouts/datahub-base.njk
@@ -56,3 +56,5 @@
     {% endblock %}
   <!--<![endif]-->
 {% endblock %}
+
+{% block body_footer %}{% endblock %}

--- a/src/views/_layouts/dit-base.njk
+++ b/src/views/_layouts/dit-base.njk
@@ -46,15 +46,19 @@
         <header role="banner" class="global-header">
           <div class="global-header__inner">
             {% block header_site_title %}
-              <a href="/" class="global-header__link">
-                {{ siteTitle|default('Department for International Trade') }}
-              </a>
+              <div class="global-header__site-title">
+                <a href="/" class="global-header__logo">
+                  <span class="global-header__site-name">{{ siteTitle|default('Department for International Trade') }}</span>
+                  {% if serviceTitle %}
+                    <span class="global-header__service-name">{{ serviceTitle }}</span>
+                  {% endif %}
+                </a>
+                {% if not phaseBanner and projectPhase|lower in ['alpha', 'beta'] %}
+                  <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
+                {% endif %}
+              </div>
             {% endblock %}
-            {% block header_service_title %}
-              {% if serviceTitle %}
-                <span class="global-header__service-name">{{ serviceTitle }}</span>
-              {% endif %}
-            {% endblock %}
+            {% block header_menu %}{% endblock %}
           </div>
         </header>
       {% endblock %}
@@ -63,32 +67,17 @@
         <div class="main-content">
           <main id="main-content" role="main" class="main-content__inner">
             {% block body_main_header %}
-              {% if projectPhase|lower in ['alpha', 'beta'] and feedbackLink %}
+              {% if phaseBanner and (projectPhase|lower in ['alpha', 'beta'] or feedbackLink) %}
                 <div class="phase-banner">
-                  <span class="phase-banner__tag">{{ projectPhase.toUpperCase() }}</span>
+                  <span class="phase-badge">{{ projectPhase.toUpperCase() }}</span>
                   <span class="phase-banner__message">
-                    This is a new service – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
+                    This is a new service
+                    {% if feedbackLink %}
+                    – your <a href="{{ feedbackLink }}">feedback</a> will help us to improve it.
+                    {% endif %}
                   </span>
                 </div>
               {% endif %}
-              {% block body_main_header_content %}
-                <div class="global-nav">
-                  <nav class="global-nav__navigation">
-                    <a href="/" class="global-nav__link">Home</a>
-                  </nav>
-                  {% if user.name %}
-                    <ul class="global-nav__account">
-                      <li class="global-nav__item">
-                        <span class="global-nav__username">{{ user.name }}:</span>
-                        <a href="/myaccount" class="global-nav__link">My account</a>
-                      </li>
-                      <li class="global-nav__item">
-                        <a href="/login/signout" class="global-nav__link">Sign out</a>
-                      </li>
-                    </ul>
-                  {% endif %}
-                </div>
-              {% endblock %}
             {% endblock %}
             {% block body_main_content %}{% endblock %}
           </main>

--- a/src/views/login.njk
+++ b/src/views/login.njk
@@ -4,7 +4,7 @@
 {% block body_main_header_content %}{% endblock %}
 
 {% block body_main_content %}
-  <h2 class="heading-xlarge">Login</h2>
+  <h2 class="heading-xlarge">Sign in</h2>
 
   {% if messages.error.length %}
     <div class="flash-message error-message">
@@ -30,8 +30,8 @@
 
   <form action="" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ trade.textbox('username', label="Username", error=errors.username, autofocus=true) }}
+    {{ trade.textbox('username', label="Email address", error=errors.username, autofocus=true) }}
     {{ trade.textbox('password', label="Password", error=errors.password, type='password', autocomplete=false) }}
-    {{ trade.save(buttonText='Login') }}
+    {{ trade.save(buttonText='Sign in') }}
   </form>
 {% endblock %}


### PR DESCRIPTION
This change includes some updates to the header/footer layouts:

- Option to remove phase banner and display phase tag next to site title
- Ability to add a proposition menu to global header
- Remove crown copyright from footer until we know we can include it
- Copy tweaks to sign in/sign out

## Not signed in 

### Before
![before-login](https://user-images.githubusercontent.com/3327997/27002783-a07a7124-4de1-11e7-9d58-ba9522ce80fc.png)

### After
![login-after](https://user-images.githubusercontent.com/3327997/27002780-9a3a2a66-4de1-11e7-9ea7-cd7b1176b155.png)

## Signed in

### Before
![before](https://user-images.githubusercontent.com/3327997/27002773-85bff2d2-4de1-11e7-8e62-ce375db58b4b.png)

### After
![after](https://user-images.githubusercontent.com/3327997/27002775-8a8b2d04-4de1-11e7-83c1-3fc47004e4c0.png)

