### PR TITLE
Fix issues in IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "compression": "^1.6.2",
     "connect-flash": "0.1.1",
     "connect-redis-crypto": "3.1.1",
+    "core-js": "^2.4.1",
     "csurf": "^1.9.0",
     "date-fns": "^1.28.5",
     "dotenv": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-eslint": "^7.2.3",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-class-properties": "^6.19.0",
-    "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.14.0",
     "body-parser": "^1.15.2",
     "browser-sync": "^2.14.2",

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -1,3 +1,4 @@
+require('core-js/fn/array/from')
 const ConditionalSubfields = require('./modules/conditional-subfields')
 const SortableTable = require('./modules/sortable-table')
 const DetailsList = require('./modules/details-list')

--- a/src/javascripts/modules/conditional-subfields.js
+++ b/src/javascripts/modules/conditional-subfields.js
@@ -116,11 +116,7 @@ const ConditionalSubfields = {
       const value = subField.getAttribute('data-control-value') + ''
       let isVisible
 
-      if (controlInputValue === value) {
-        isVisible = true
-      } else {
-        isVisible = false
-      }
+      isVisible = controlInputValue === value
 
       this._toggleSubField(subField, isVisible)
     })

--- a/src/javascripts/modules/details-list.js
+++ b/src/javascripts/modules/details-list.js
@@ -41,7 +41,7 @@ class ExpandableDetails {
   }
 
   static init () {
-    document.querySelectorAll('.js-details-expandable')
+    Array.from(document.querySelectorAll('.js-details-expandable'))
       .forEach((element) => new ExpandableDetails(element))
   }
 }

--- a/test/repos/company.repo.test.js
+++ b/test/repos/company.repo.test.js
@@ -1,5 +1,4 @@
 /* eslint prefer-promise-reject-errors: 0 */
-require('babel-polyfill')
 
 describe('Company repository', () => {
   describe('Save company', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,14 +625,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.20.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
-  dependencies:
-    babel-runtime "^6.22.0"
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
 babel-preset-es2015@^6.14.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,7 +1291,7 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 


### PR DESCRIPTION
This fixes JS errors in IE9 which prevented the rest of the scripts loading in `app.js` after undefined `Array.from` error was encountered.

- Remove unused babel-polyfill module
- Add [core-js](https://github.com/zloirock/core-js) polyfill library to be able to selectively polyfill required ES5 features
- Simplify boolean logic