### PR TITLE
middleware to trim strings found in req.body

### DIFF
--- a/src/middleware/trimBodyParams.js
+++ b/src/middleware/trimBodyParams.js
@@ -1,0 +1,30 @@
+const { size } = require('lodash')
+
+/**
+ * Trim whitespace from req.body strings
+ * @param obj
+ * @returns {*}
+ */
+function trim (obj) {
+  for (let prop in obj) {
+    let value = obj[prop]
+
+    if (typeof value === 'string') {
+      obj[prop] = value.trim()
+    } else if (value instanceof Array) {
+      obj[prop] = trim(value)
+    }
+  }
+
+  return obj
+}
+
+module.exports = () => {
+  return function trimBodyParams (req, res, next) {
+    if (size(req.body)) {
+      req.body = trim(Object.assign({}, req.body))
+    }
+
+    next()
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -22,6 +22,7 @@ const user = require('./middleware/user')
 const auth = require('./middleware/auth')
 const csrfToken = require('./middleware/csrf-token')
 const errors = require('./middleware/errors')
+const trimBodyParams = require('./middleware/trimBodyParams')
 const logger = require('../config/logger')
 
 const router = require('../config/routes')
@@ -112,6 +113,7 @@ app.use(auth)
 app.use(user)
 app.use(headers)
 
+app.post('*', trimBodyParams())
 // routing
 app.use(slashify())
 app.use('/', router)

--- a/test/middleware/trimBodyParams.test.js
+++ b/test/middleware/trimBodyParams.test.js
@@ -1,0 +1,65 @@
+describe('Trim Body Params Middleware Test', () => {
+  beforeEach(() => {
+    this.sandbox = sinon.sandbox.create()
+    this.nextSpy = this.sandbox.spy()
+    this.trimBodyParams = require('~/src/middleware/trimBodyParams')()
+  })
+
+  afterEach(() => {
+    this.sandbox.restore()
+  })
+
+  it('when body is empty should not modify body', () => {
+    const mockReq = {
+      body: {},
+    }
+
+    this.trimBodyParams(
+      mockReq,
+      {},
+      this.nextSpy)
+
+    expect(this.nextSpy.calledOnce).to.be.true
+    expect(mockReq.body).to.deep.equal({})
+  })
+
+  it('when body has values strings should be trimmed', () => {
+    const mockReq = {
+      body: {
+        example: '    test   ',
+      },
+    }
+
+    this.trimBodyParams(
+      mockReq,
+      {},
+      this.nextSpy)
+
+    expect(this.nextSpy.calledOnce).to.be.true
+    expect(mockReq.body.example).to.equal('test')
+  })
+
+  it('when body has arrays the strings values should be trimmed', () => {
+    const mockReq = {
+      body: {
+        example: '    test   ',
+        exampleArray: [
+          '  an',
+          ' example    ',
+          '   test',
+        ],
+      },
+    }
+
+    this.trimBodyParams(
+      mockReq,
+      {},
+      this.nextSpy)
+
+    expect(this.nextSpy.calledOnce).to.be.true
+    expect(mockReq.body.example).to.equal('test')
+    expect(mockReq.body.exampleArray[0]).to.equal('an')
+    expect(mockReq.body.exampleArray[1]).to.equal('example')
+    expect(mockReq.body.exampleArray[2]).to.equal('test')
+  })
+})


### PR DESCRIPTION
This work trims whitespace from strings found in `req.body` posts. 

Currently you cannot login when your username has trailing whitespace. 