### PR TITLE
Update test configuration

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -30,7 +30,7 @@ module.exports = {
     // 2 hour timeout
     ttl: process.env.SESSION_TTL || (2 * 60 * 60 * 1000),
   },
-  logLevel: process.env.LOG_LEVEL || isDev ? 'debug' : 'error',
+  logLevel: process.env.LOG_LEVEL || (isDev ? 'debug' : 'error'),
   zenUrl: `https://${process.env.ZEN_DOMAIN}.zendesk.com/api/v2/tickets.json`,
   zenToken: process.env.ZEN_TOKEN,
   zenEmail: process.env.ZEN_EMAIL,

--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
     "clean": "rm -rf build",
     "start": "node --use-strict src/server.js",
     "build": "npm run clean && npm run sass:compile && npm run js",
-    "test": "mocha --recursive test/unit/",
-    "test:watch": "npm test -- -w",
+    "test": "npm run test:unit && npm run test:acceptance",
+    "test:unit": "NODE_ENV=test LOG_LEVEL=silent mocha ./test/unit --opts ./test/unit/mocha.opts",
+    "test:watch": "npm run test:unit -- -w",
     "test:acceptance": "nightwatch --config test/acceptance/nightwatch.conf.js",
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov npm run test",
     "lint": "npm run lint:js && npm run lint:sass",
@@ -86,7 +87,7 @@
     "sass:compile": "npm run sass -- -x --output-style compressed",
     "css:autoprefixer": "postcss build/css/*.css --use autoprefixer -d build/css",
     "sync": "browser-sync start --proxy http://localhost:3000 --files build/css/*.css build/javascripts/*.js",
-    "circle": "npm run lint && nyc --reporter=lcov npm test -- --reporter mocha-circleci-reporter && npm run sass && npm run js && codeclimate-test-reporter < coverage/lcov.info",
+    "circle": "npm run lint && nyc --reporter=lcov npm run test:unit -- --reporter mocha-circleci-reporter && npm run sass && npm run js && codeclimate-test-reporter < coverage/lcov.info",
     "heroku-postbuild": "npm rebuild node-sass && npm run sass && npm run js"
   },
   "pre-commit": [

--- a/test/unit/mocha.opts
+++ b/test/unit/mocha.opts
@@ -1,4 +1,4 @@
 --require test/unit/common.js
 --ui bdd
 --recursive
---reporter list
+--reporter dot


### PR DESCRIPTION
- Move mocha options into the unit test folder as they are only
used here
- Make the default `test` command run but unit and acceptance tests

## Reporter

This change also changes the default reporter style to be more compact. It swaps the [list reporter](https://mochajs.org/#list) for the [dot matrix reporter](https://mochajs.org/#dot-matrix).

### Before

<img width="709" alt="screen shot 2017-06-22 at 12 21 41" src="https://user-images.githubusercontent.com/3327997/27431742-7adbe836-5745-11e7-8d1c-f479f17665cd.png">

### After

<img width="568" alt="screen shot 2017-06-22 at 12 21 14" src="https://user-images.githubusercontent.com/3327997/27431745-801962d8-5745-11e7-8df5-72254dbdafe8.png">
